### PR TITLE
test: #31 Unit tests + separate object mappers mock

### DIFF
--- a/src/main/java/org/qubership/integration/platform/engine/service/IdempotencyRecordService.java
+++ b/src/main/java/org/qubership/integration/platform/engine/service/IdempotencyRecordService.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2024-2025 NetCracker Technology Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.qubership.integration.platform.engine.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;

--- a/src/test/java/org/qubership/integration/platform/engine/service/CheckpointSessionServiceTest.java
+++ b/src/test/java/org/qubership/integration/platform/engine/service/CheckpointSessionServiceTest.java
@@ -1,0 +1,382 @@
+/*
+ * Copyright 2024-2025 NetCracker Technology Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.qubership.integration.platform.engine.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.quarkus.panache.common.Page;
+import io.quarkus.panache.common.Sort;
+import io.smallrye.mutiny.Uni;
+import io.vertx.mutiny.core.buffer.Buffer;
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.ws.rs.core.MediaType;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.http.HttpHeaders;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.qubership.integration.platform.engine.model.constants.CamelConstants.Headers;
+import org.qubership.integration.platform.engine.persistence.shared.entity.Checkpoint;
+import org.qubership.integration.platform.engine.persistence.shared.entity.SessionInfo;
+import org.qubership.integration.platform.engine.persistence.shared.repository.CheckpointRepository;
+import org.qubership.integration.platform.engine.persistence.shared.repository.SessionInfoRepository;
+import org.qubership.integration.platform.engine.testutils.DisplayNameUtils;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Supplier;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@DisplayNameGeneration(DisplayNameUtils.ReplaceCamelCase.class)
+class CheckpointSessionServiceTest {
+
+    private CheckpointSessionService service(
+            SessionInfoRepository sessionInfoRepository,
+            CheckpointRepository checkpointRepository,
+            CheckpointRestService checkpointRestService,
+            ObjectMapper mapper
+    ) {
+        return new CheckpointSessionService(sessionInfoRepository, checkpointRepository, checkpointRestService, mapper);
+    }
+
+    @Test
+    void shouldThrowEntityNotFoundWhenRetryFromLastCheckpointAndNoCheckpoint() {
+        SessionInfoRepository sessionRepo = mock(SessionInfoRepository.class);
+        CheckpointRepository checkpointRepo = mock(CheckpointRepository.class);
+        CheckpointRestService rest = mock(CheckpointRestService.class);
+
+        CheckpointSessionService svc = service(sessionRepo, checkpointRepo, rest, mock(ObjectMapper.class));
+
+        when(checkpointRepo.findAllBySessionChainIdAndSessionId(anyString(), anyString(), any(Page.class), any(Sort.class)))
+                .thenReturn(List.of());
+
+        assertThrows(EntityNotFoundException.class, () ->
+                svc.retryFromLastCheckpoint("chain", "session", "{\"x\":1}", () -> null, true)
+        );
+
+        verifyNoInteractions(rest);
+    }
+
+    @Test
+    void shouldCallRetryCheckpointWhenRetryFromLastCheckpointAndCheckpointExists() {
+        SessionInfoRepository sessionRepo = mock(SessionInfoRepository.class);
+        CheckpointRepository checkpointRepo = mock(CheckpointRepository.class);
+        CheckpointRestService rest = mock(CheckpointRestService.class);
+
+        Uni<Buffer> uni = mock(Uni.class, RETURNS_DEEP_STUBS);
+        when(rest.retryCheckpoint(anyString(), anyString(), anyString(), anyMap(), any())).thenReturn(uni);
+
+        CheckpointSessionService svc = service(sessionRepo, checkpointRepo, rest, mock(ObjectMapper.class));
+
+        SessionInfo session = mock(SessionInfo.class);
+        when(session.getChainId()).thenReturn("chain");
+        when(session.getId()).thenReturn("session");
+
+        Checkpoint checkpoint = mock(Checkpoint.class);
+        when(checkpoint.getSession()).thenReturn(session);
+        when(checkpoint.getCheckpointElementId()).thenReturn("el-1");
+
+        when(checkpointRepo.findAllBySessionChainIdAndSessionId(eq("chain"), eq("session"), any(Page.class), any(Sort.class)))
+                .thenReturn(List.of(checkpoint));
+
+        Supplier<Pair<String, String>> auth = () -> Pair.of("Authorization", "Bearer 123");
+
+        svc.retryFromLastCheckpoint("chain", "session", "{\"k\":\"v\"}", auth, true);
+
+        ArgumentCaptor<Map<String, String>> headersCaptor = ArgumentCaptor.forClass(Map.class);
+        ArgumentCaptor<Optional<String>> bodyCaptor = ArgumentCaptor.forClass(Optional.class);
+
+        verify(rest).retryCheckpoint(eq("chain"), eq("session"), eq("el-1"), headersCaptor.capture(), bodyCaptor.capture());
+
+        Map<String, String> hdrs = headersCaptor.getValue();
+        assertEquals("Bearer 123", hdrs.get("Authorization"));
+        assertEquals("true", hdrs.get(Headers.TRACE_ME));
+        assertEquals(MediaType.APPLICATION_JSON, hdrs.get(HttpHeaders.CONTENT_TYPE));
+
+        assertEquals(Optional.of("{\"k\":\"v\"}"), bodyCaptor.getValue());
+
+        verify(uni).subscribe();
+    }
+
+    @Test
+    void shouldSendEmptyOptionalBodyWhenBodyBlank() {
+        SessionInfoRepository sessionRepo = mock(SessionInfoRepository.class);
+        CheckpointRepository checkpointRepo = mock(CheckpointRepository.class);
+        CheckpointRestService rest = mock(CheckpointRestService.class);
+
+        @SuppressWarnings("unchecked")
+        Uni<Buffer> uni = mock(Uni.class, RETURNS_DEEP_STUBS);
+
+        when(rest.retryCheckpoint(
+                anyString(), anyString(), anyString(),
+                org.mockito.ArgumentMatchers.anyMap(),
+                org.mockito.ArgumentMatchers.any()
+        )).thenReturn(uni);
+
+        CheckpointSessionService svc = service(sessionRepo, checkpointRepo, rest, mock(ObjectMapper.class));
+
+        SessionInfo session = mock(SessionInfo.class);
+        when(session.getChainId()).thenReturn("chain");
+        when(session.getId()).thenReturn("session");
+
+        Checkpoint checkpoint = mock(Checkpoint.class);
+        when(checkpoint.getSession()).thenReturn(session);
+        when(checkpoint.getCheckpointElementId()).thenReturn("el-1");
+
+        when(checkpointRepo.findAllBySessionChainIdAndSessionId(eq("chain"), eq("session"), any(Page.class), any(Sort.class)))
+                .thenReturn(List.of(checkpoint));
+
+        svc.retryFromLastCheckpoint("chain", "session", "", () -> null, false);
+
+        ArgumentCaptor<Map<String, String>> headersCaptor = ArgumentCaptor.forClass(Map.class);
+        ArgumentCaptor<Optional<String>> bodyCaptor = ArgumentCaptor.forClass(Optional.class);
+
+        verify(rest).retryCheckpoint(eq("chain"), eq("session"), eq("el-1"), headersCaptor.capture(), bodyCaptor.capture());
+
+        Map<String, String> hdrs = headersCaptor.getValue();
+        assertEquals("false", hdrs.get(org.qubership.integration.platform.engine.model.constants.CamelConstants.Headers.TRACE_ME));
+        assertEquals(MediaType.APPLICATION_JSON, hdrs.get(HttpHeaders.CONTENT_TYPE));
+        assertEquals(Optional.empty(), bodyCaptor.getValue());
+
+        verify(uni).subscribe();
+    }
+
+    @Test
+    void shouldThrowEntityNotFoundWhenRetryFromCheckpointAndCheckpointMissing() {
+        SessionInfoRepository sessionRepo = mock(SessionInfoRepository.class);
+        CheckpointRepository checkpointRepo = mock(CheckpointRepository.class);
+        CheckpointRestService rest = mock(CheckpointRestService.class);
+
+        CheckpointSessionService svc = service(sessionRepo, checkpointRepo, rest, mock(ObjectMapper.class));
+
+        when(checkpointRepo.findFirstBySessionIdAndSessionChainIdAndCheckpointElementId(anyString(), anyString(), anyString()))
+                .thenReturn(null);
+
+        assertThrows(EntityNotFoundException.class, () ->
+                svc.retryFromCheckpoint("chain", "session", "el-1", "{}", () -> null, true)
+        );
+
+        verifyNoInteractions(rest);
+    }
+
+    @Test
+    void shouldCallRetryCheckpointWhenRetryFromCheckpointAndCheckpointExists() {
+        SessionInfoRepository sessionRepo = mock(SessionInfoRepository.class);
+        CheckpointRepository checkpointRepo = mock(CheckpointRepository.class);
+        CheckpointRestService rest = mock(CheckpointRestService.class);
+
+        Uni<Buffer> uni = mock(Uni.class, RETURNS_DEEP_STUBS);
+        when(rest.retryCheckpoint(anyString(), anyString(), anyString(), anyMap(), any())).thenReturn(uni);
+
+        CheckpointSessionService svc = service(sessionRepo, checkpointRepo, rest, mock(ObjectMapper.class));
+
+        SessionInfo session = mock(SessionInfo.class);
+        when(session.getChainId()).thenReturn("chain");
+        when(session.getId()).thenReturn("session");
+
+        Checkpoint checkpoint = mock(Checkpoint.class);
+        when(checkpoint.getSession()).thenReturn(session);
+        when(checkpoint.getCheckpointElementId()).thenReturn("el-1");
+
+        when(checkpointRepo.findFirstBySessionIdAndSessionChainIdAndCheckpointElementId("session", "chain", "el-1"))
+                .thenReturn(checkpoint);
+
+        svc.retryFromCheckpoint("chain", "session", "el-1", "{\"a\":1}", () -> Pair.of("X", "Y"), true);
+
+        ArgumentCaptor<Map<String, String>> headersCaptor = ArgumentCaptor.forClass(Map.class);
+        ArgumentCaptor<Optional<String>> bodyCaptor = ArgumentCaptor.forClass(Optional.class);
+
+        verify(rest).retryCheckpoint(eq("chain"), eq("session"), eq("el-1"), headersCaptor.capture(), bodyCaptor.capture());
+
+        Map<String, String> hdrs = headersCaptor.getValue();
+        assertEquals("Y", hdrs.get("X"));
+        assertEquals("true", hdrs.get(Headers.TRACE_ME));
+        assertEquals(MediaType.APPLICATION_JSON, hdrs.get(HttpHeaders.CONTENT_TYPE));
+        assertEquals(Optional.of("{\"a\":1}"), bodyCaptor.getValue());
+
+        verify(uni).subscribe();
+    }
+
+    @Test
+    void shouldReturnNullWhenFindLastCheckpointAndRepositoryReturnsNullOrEmpty() {
+        SessionInfoRepository sessionRepo = mock(SessionInfoRepository.class);
+        CheckpointRepository checkpointRepo = mock(CheckpointRepository.class);
+
+        CheckpointSessionService svc = service(sessionRepo, checkpointRepo, mock(CheckpointRestService.class), mock(ObjectMapper.class));
+
+        when(checkpointRepo.findAllBySessionChainIdAndSessionId(anyString(), anyString(), any(Page.class), any(Sort.class)))
+                .thenReturn(null);
+
+        assertNull(svc.findLastCheckpoint("c", "s"));
+
+        when(checkpointRepo.findAllBySessionChainIdAndSessionId(anyString(), anyString(), any(Page.class), any(Sort.class)))
+                .thenReturn(List.of());
+
+        assertNull(svc.findLastCheckpoint("c", "s"));
+    }
+
+    @Test
+    void shouldReturnFirstWhenFindLastCheckpointAndRepositoryReturnsList() {
+        SessionInfoRepository sessionRepo = mock(SessionInfoRepository.class);
+        CheckpointRepository checkpointRepo = mock(CheckpointRepository.class);
+
+        CheckpointSessionService svc = service(sessionRepo, checkpointRepo, mock(CheckpointRestService.class), mock(ObjectMapper.class));
+
+        Checkpoint c1 = mock(Checkpoint.class);
+        Checkpoint c2 = mock(Checkpoint.class);
+
+        when(checkpointRepo.findAllBySessionChainIdAndSessionId(eq("c"), eq("s"), any(Page.class), any(Sort.class)))
+                .thenReturn(List.of(c1, c2));
+
+        assertSame(c1, svc.findLastCheckpoint("c", "s"));
+    }
+
+    @Test
+    void shouldDelegateFindAllFailedChainSessionsInfo() {
+        SessionInfoRepository sessionRepo = mock(SessionInfoRepository.class);
+        CheckpointRepository checkpointRepo = mock(CheckpointRepository.class);
+
+        CheckpointSessionService svc = service(sessionRepo, checkpointRepo, mock(CheckpointRestService.class), mock(ObjectMapper.class));
+
+        List<SessionInfo> list = List.of(mock(SessionInfo.class));
+        when(sessionRepo.findAllByChainIdAndExecutionStatus("c", ExecutionStatus.COMPLETED_WITH_ERRORS)).thenReturn(list);
+
+        assertSame(list, svc.findAllFailedChainSessionsInfo("c"));
+    }
+
+    @Test
+    void shouldPersistAndReturnSameSessionWhenSaveSession() {
+        SessionInfoRepository sessionRepo = mock(SessionInfoRepository.class);
+        CheckpointRepository checkpointRepo = mock(CheckpointRepository.class);
+
+        CheckpointSessionService svc = service(sessionRepo, checkpointRepo, mock(CheckpointRestService.class), mock(ObjectMapper.class));
+
+        SessionInfo session = mock(SessionInfo.class);
+        SessionInfo out = svc.saveSession(session);
+
+        assertSame(session, out);
+        verify(sessionRepo).persistAndFlush(session);
+    }
+
+    @Test
+    void shouldThrowEntityNotFoundWhenSaveAndAssignCheckpointAndSessionMissing() {
+        SessionInfoRepository sessionRepo = mock(SessionInfoRepository.class);
+        CheckpointRepository checkpointRepo = mock(CheckpointRepository.class);
+
+        CheckpointSessionService svc = service(sessionRepo, checkpointRepo, mock(CheckpointRestService.class), mock(ObjectMapper.class));
+
+        when(sessionRepo.findByIdOptional("s")).thenReturn(Optional.empty());
+
+        Checkpoint checkpoint = mock(Checkpoint.class);
+
+        assertThrows(EntityNotFoundException.class, () -> svc.saveAndAssignCheckpoint(checkpoint, "s"));
+    }
+
+    @Test
+    void shouldAssignCheckpointToSessionWhenSaveAndAssignCheckpointAndSessionExists() {
+        SessionInfoRepository sessionRepo = mock(SessionInfoRepository.class);
+        CheckpointRepository checkpointRepo = mock(CheckpointRepository.class);
+
+        CheckpointSessionService svc = service(sessionRepo, checkpointRepo, mock(CheckpointRestService.class), mock(ObjectMapper.class));
+
+        SessionInfo session = mock(SessionInfo.class);
+        when(sessionRepo.findByIdOptional("s")).thenReturn(Optional.of(session));
+
+        Checkpoint checkpoint = mock(Checkpoint.class);
+
+        @SuppressWarnings({"rawtypes", "unchecked"})
+        List props = List.of("a");
+
+        when(checkpoint.getProperties()).thenReturn(props);
+
+        svc.saveAndAssignCheckpoint(checkpoint, "s");
+
+        verify(checkpoint).assignProperties(props);
+        verify(session).assignCheckpoint(checkpoint);
+    }
+
+    @Test
+    void shouldUpdateParentWhenBothSessionsExist() {
+        SessionInfoRepository sessionRepo = mock(SessionInfoRepository.class);
+        CheckpointRepository checkpointRepo = mock(CheckpointRepository.class);
+
+        CheckpointSessionService svc = service(sessionRepo, checkpointRepo, mock(CheckpointRestService.class), mock(ObjectMapper.class));
+
+        SessionInfo session = mock(SessionInfo.class);
+        SessionInfo parent = mock(SessionInfo.class);
+
+        when(sessionRepo.findByIdOptional("s")).thenReturn(Optional.of(session));
+        when(sessionRepo.findByIdOptional("p")).thenReturn(Optional.of(parent));
+
+        svc.updateSessionParent("s", "p");
+
+        verify(session).setParentSession(parent);
+    }
+
+    @Test
+    void shouldThrowEntityNotFoundWhenUpdateParentAndAnySessionMissing() {
+        SessionInfoRepository sessionRepo = mock(SessionInfoRepository.class);
+        CheckpointRepository checkpointRepo = mock(CheckpointRepository.class);
+
+        CheckpointSessionService svc = service(sessionRepo, checkpointRepo, mock(CheckpointRestService.class), mock(ObjectMapper.class));
+
+        when(sessionRepo.findByIdOptional("s")).thenReturn(Optional.empty());
+
+        assertThrows(EntityNotFoundException.class, () -> svc.updateSessionParent("s", "p"));
+    }
+
+    @Test
+    void shouldDeleteRootSessionByIdWhenRemoveAllRelatedCheckpointsAndIsRoot() {
+        SessionInfoRepository sessionRepo = mock(SessionInfoRepository.class);
+        CheckpointRepository checkpointRepo = mock(CheckpointRepository.class);
+
+        CheckpointSessionService svc = service(sessionRepo, checkpointRepo, mock(CheckpointRestService.class), mock(ObjectMapper.class));
+
+        svc.removeAllRelatedCheckpoints("s", true);
+
+        verify(sessionRepo).deleteById("s");
+        verify(sessionRepo, never()).deleteAllRelatedSessionsAndCheckpoints(anyString());
+    }
+
+    @Test
+    void shouldDeleteRelatedWhenRemoveAllRelatedCheckpointsAndNotRoot() {
+        SessionInfoRepository sessionRepo = mock(SessionInfoRepository.class);
+        CheckpointRepository checkpointRepo = mock(CheckpointRepository.class);
+
+        CheckpointSessionService svc = service(sessionRepo, checkpointRepo, mock(CheckpointRestService.class), mock(ObjectMapper.class));
+
+        svc.removeAllRelatedCheckpoints("s", false);
+
+        verify(sessionRepo).deleteAllRelatedSessionsAndCheckpoints("s");
+        verify(sessionRepo, never()).deleteById(anyString());
+    }
+
+    @Test
+    void shouldDelegateDeleteOldRecordsByInterval() {
+        SessionInfoRepository sessionRepo = mock(SessionInfoRepository.class);
+        CheckpointRepository checkpointRepo = mock(CheckpointRepository.class);
+
+        CheckpointSessionService svc = service(sessionRepo, checkpointRepo, mock(CheckpointRestService.class), mock(ObjectMapper.class));
+
+        svc.deleteOldRecordsByInterval("P30D");
+
+        verify(sessionRepo).deleteOldRecordsByInterval("P30D");
+    }
+}

--- a/src/test/java/org/qubership/integration/platform/engine/service/DeploymentsUpdateServiceTest.java
+++ b/src/test/java/org/qubership/integration/platform/engine/service/DeploymentsUpdateServiceTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright 2024-2025 NetCracker Technology Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.qubership.integration.platform.engine.service;
+
+import jakarta.inject.Inject;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.qubership.integration.platform.engine.catalog.RuntimeCatalogService;
+import org.qubership.integration.platform.engine.model.deployment.engine.EngineDeploymentsDTO;
+import org.qubership.integration.platform.engine.model.deployment.engine.EngineInfo;
+import org.qubership.integration.platform.engine.model.deployment.update.DeploymentInfo;
+import org.qubership.integration.platform.engine.model.deployment.update.DeploymentsUpdate;
+import org.qubership.integration.platform.engine.testutils.DisplayNameUtils;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameUtils.ReplaceCamelCase.class)
+class DeploymentsUpdateServiceTest {
+
+    @Mock
+    IntegrationRuntimeService integrationRuntimeService;
+
+    @Mock
+    EngineInfo engineInfo;
+
+    @RestClient
+    @Inject
+    @Mock
+    RuntimeCatalogService runtimeCatalogService;
+
+    @InjectMocks
+    DeploymentsUpdateService service;
+
+    @Test
+    void shouldCallCatalogWithDomainAndExcludedWhenGetAndProcess() throws Exception {
+        List<DeploymentInfo> excludedDeployments = List.of(mock(DeploymentInfo.class), mock(DeploymentInfo.class));
+        DeploymentsUpdate update = mock(DeploymentsUpdate.class);
+
+        when(integrationRuntimeService.buildExcludeDeploymentsMap()).thenReturn(excludedDeployments);
+        when(engineInfo.getDomain()).thenReturn("test-domain");
+        when(runtimeCatalogService.getDeploymentsUpdate(anyString(), any(EngineDeploymentsDTO.class))).thenReturn(update);
+
+        ArgumentCaptor<EngineDeploymentsDTO> dtoCaptor = ArgumentCaptor.forClass(EngineDeploymentsDTO.class);
+
+        service.getAndProcess();
+
+        verify(runtimeCatalogService).getDeploymentsUpdate(eq("test-domain"), dtoCaptor.capture());
+        EngineDeploymentsDTO captured = dtoCaptor.getValue();
+        assertEquals(excludedDeployments, captured.getExcludeDeployments());
+
+        verify(integrationRuntimeService).processAndUpdateState(same(update), eq(false));
+    }
+
+    @Test
+    void shouldCallDependenciesInOrderWhenGetAndProcess() throws Exception {
+        List<DeploymentInfo> excludedDeployments = List.of(mock(DeploymentInfo.class));
+        DeploymentsUpdate update = mock(DeploymentsUpdate.class);
+
+        when(integrationRuntimeService.buildExcludeDeploymentsMap()).thenReturn(excludedDeployments);
+        when(engineInfo.getDomain()).thenReturn("domain");
+        when(runtimeCatalogService.getDeploymentsUpdate(anyString(), any(EngineDeploymentsDTO.class))).thenReturn(update);
+
+        InOrder inOrder = inOrder(integrationRuntimeService, engineInfo, runtimeCatalogService);
+
+        service.getAndProcess();
+
+        inOrder.verify(integrationRuntimeService).buildExcludeDeploymentsMap();
+        inOrder.verify(engineInfo).getDomain();
+        inOrder.verify(runtimeCatalogService).getDeploymentsUpdate(eq("domain"), any(EngineDeploymentsDTO.class));
+
+        verify(integrationRuntimeService).processAndUpdateState(same(update), eq(false));
+    }
+
+    @Test
+    void shouldPropagateExceptionWhenBuildExcludeDeploymentsMapThrows() throws Exception {
+        Exception boom = new Exception("boom");
+        when(integrationRuntimeService.buildExcludeDeploymentsMap()).thenThrow(boom);
+
+        try {
+            service.getAndProcess();
+        } catch (Exception ex) {
+            assertEquals(boom, ex);
+        }
+
+        verifyNoInteractions(engineInfo, runtimeCatalogService);
+        verify(integrationRuntimeService, never()).processAndUpdateState(any(), anyBoolean());
+    }
+
+    @Test
+    void shouldPropagateRuntimeExceptionWhenCatalogClientThrows() throws Exception {
+        when(integrationRuntimeService.buildExcludeDeploymentsMap()).thenReturn(List.of(mock(DeploymentInfo.class)));
+        when(engineInfo.getDomain()).thenReturn("domain");
+
+        RuntimeException boom = new RuntimeException("catalog down");
+        when(runtimeCatalogService.getDeploymentsUpdate(anyString(), any(EngineDeploymentsDTO.class))).thenThrow(boom);
+
+        try {
+            service.getAndProcess();
+        } catch (RuntimeException ex) {
+            assertEquals(boom, ex);
+        }
+
+        verify(integrationRuntimeService, never()).processAndUpdateState(any(), anyBoolean());
+    }
+
+    @Test
+    void shouldPropagateExceptionWhenProcessAndUpdateStateThrows() throws Exception {
+        when(integrationRuntimeService.buildExcludeDeploymentsMap()).thenReturn(List.of(mock(DeploymentInfo.class)));
+        when(engineInfo.getDomain()).thenReturn("domain");
+
+        DeploymentsUpdate update = mock(DeploymentsUpdate.class);
+        when(runtimeCatalogService.getDeploymentsUpdate(anyString(), any(EngineDeploymentsDTO.class))).thenReturn(update);
+
+        Exception boom = new Exception("processing failed");
+        doThrow(boom).when(integrationRuntimeService).processAndUpdateState(same(update), eq(false));
+
+        try {
+            service.getAndProcess();
+        } catch (Exception ex) {
+            assertEquals(boom, ex);
+        }
+    }
+}

--- a/src/test/java/org/qubership/integration/platform/engine/service/IdempotencyRecordServiceTest.java
+++ b/src/test/java/org/qubership/integration/platform/engine/service/IdempotencyRecordServiceTest.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright 2024-2025 NetCracker Technology Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.qubership.integration.platform.engine.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.qubership.integration.platform.engine.persistence.shared.repository.IdempotencyRecordRepository;
+import org.qubership.integration.platform.engine.testutils.DisplayNameUtils;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameUtils.ReplaceCamelCase.class)
+class IdempotencyRecordServiceTest {
+
+    @Mock
+    ObjectMapper objectMapper;
+
+    @Mock
+    IdempotencyRecordRepository idempotencyRecordRepository;
+
+    @InjectMocks
+    IdempotencyRecordService service;
+
+    @Test
+    void shouldReturnTrueWhenInsertIfNotExistsOrUpdateIfExpiredReturnsPositive() throws Exception {
+        when(objectMapper.writeValueAsString(any())).thenReturn("{\"status\":\"RECEIVED\"}");
+        when(idempotencyRecordRepository.insertIfNotExistsOrUpdateIfExpired(anyString(), any(), anyInt()))
+                .thenReturn(1);
+
+        ArgumentCaptor<String> dataCaptor = ArgumentCaptor.forClass(String.class);
+
+        boolean result = service.insertIfNotExists("k1", 123);
+
+        assertTrue(result);
+
+        verify(idempotencyRecordRepository).insertIfNotExistsOrUpdateIfExpired(eq("k1"), dataCaptor.capture(), eq(123));
+        assertEquals("{\"status\":\"RECEIVED\"}", dataCaptor.getValue());
+    }
+
+    @Test
+    void shouldReturnFalseWhenInsertIfNotExistsOrUpdateIfExpiredReturnsZero() throws Exception {
+        when(objectMapper.writeValueAsString(any())).thenReturn("{\"status\":\"RECEIVED\"}");
+        when(idempotencyRecordRepository.insertIfNotExistsOrUpdateIfExpired(anyString(), any(), anyInt()))
+                .thenReturn(0);
+
+        boolean result = service.insertIfNotExists("k1", 123);
+
+        assertFalse(result);
+        verify(idempotencyRecordRepository).insertIfNotExistsOrUpdateIfExpired(eq("k1"), any(), eq(123));
+    }
+
+    @Test
+    void shouldPassNullDataWhenJsonSerializationFails() throws Exception {
+        when(objectMapper.writeValueAsString(any()))
+                .thenThrow(new JsonProcessingException("boom") {
+                });
+
+        when(idempotencyRecordRepository.insertIfNotExistsOrUpdateIfExpired(anyString(), any(), anyInt()))
+                .thenReturn(1);
+
+        ArgumentCaptor<String> dataCaptor = ArgumentCaptor.forClass(String.class);
+
+        boolean result = service.insertIfNotExists("k1", 123);
+
+        assertTrue(result);
+        verify(idempotencyRecordRepository).insertIfNotExistsOrUpdateIfExpired(eq("k1"), dataCaptor.capture(), eq(123));
+        assertNull(dataCaptor.getValue());
+    }
+
+    @Test
+    void shouldReturnRepositoryValueWhenExists() {
+        when(idempotencyRecordRepository.existsByKeyAndNotExpired("k1")).thenReturn(true);
+
+        boolean result = service.exists("k1");
+
+        assertTrue(result);
+        verify(idempotencyRecordRepository).existsByKeyAndNotExpired("k1");
+        verifyNoInteractions(objectMapper);
+    }
+
+    @Test
+    void shouldReturnTrueWhenDeleteByKeyAndNotExpiredReturnsPositive() {
+        when(idempotencyRecordRepository.deleteByKeyAndNotExpired("k1")).thenReturn(1);
+
+        boolean result = service.delete("k1");
+
+        assertTrue(result);
+        verify(idempotencyRecordRepository).deleteByKeyAndNotExpired("k1");
+        verifyNoInteractions(objectMapper);
+    }
+
+    @Test
+    void shouldReturnFalseWhenDeleteByKeyAndNotExpiredReturnsZero() {
+        when(idempotencyRecordRepository.deleteByKeyAndNotExpired("k1")).thenReturn(0);
+
+        boolean result = service.delete("k1");
+
+        assertFalse(result);
+        verify(idempotencyRecordRepository).deleteByKeyAndNotExpired("k1");
+        verifyNoInteractions(objectMapper);
+    }
+
+    @Test
+    void shouldDeleteExpiredByCallingRepository() {
+        service.deleteExpired();
+
+        verify(idempotencyRecordRepository).deleteExpired();
+        verifyNoInteractions(objectMapper);
+    }
+}

--- a/src/test/java/org/qubership/integration/platform/engine/service/LiveExchangesServiceTest.java
+++ b/src/test/java/org/qubership/integration/platform/engine/service/LiveExchangesServiceTest.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright 2024-2025 NetCracker Technology Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.qubership.integration.platform.engine.service;
+
+import jakarta.persistence.EntityNotFoundException;
+import org.apache.camel.CamelContext;
+import org.apache.camel.Exchange;
+import org.apache.camel.spi.InflightRepository;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.qubership.integration.platform.engine.camel.metadata.Metadata;
+import org.qubership.integration.platform.engine.camel.metadata.MetadataService;
+import org.qubership.integration.platform.engine.errorhandling.ChainExecutionTerminatedException;
+import org.qubership.integration.platform.engine.model.constants.CamelConstants;
+import org.qubership.integration.platform.engine.model.deployment.properties.CamelDebuggerProperties;
+import org.qubership.integration.platform.engine.rest.v1.dto.LiveExchangeDTO;
+import org.qubership.integration.platform.engine.service.debugger.CamelDebuggerPropertiesService;
+import org.qubership.integration.platform.engine.testutils.DisplayNameUtils;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Answers.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameUtils.ReplaceCamelCase.class)
+class LiveExchangesServiceTest {
+
+    @Mock
+    CamelContext camelContext;
+
+    @Mock
+    InflightRepository inflightRepository;
+
+    @Mock
+    MetadataService metadataService;
+
+    @Mock
+    CamelDebuggerPropertiesService propertiesService;
+
+    @InjectMocks
+    LiveExchangesService service;
+
+    @Test
+    void shouldBuildDtoWithDurationsWhenStartTimesPresent() {
+        when(camelContext.getInflightRepository()).thenReturn(inflightRepository);
+
+        Exchange exchange = mock(Exchange.class);
+        InflightRepository.InflightExchange holder = mock(InflightRepository.InflightExchange.class);
+        when(holder.getExchange()).thenReturn(exchange);
+
+        when(inflightRepository.browse(eq(10), eq(true))).thenReturn(List.of(holder));
+
+        when(exchange.getExchangeId()).thenReturn("ex-1");
+        when(exchange.getProperty(CamelConstants.Properties.SESSION_ID, String.class)).thenReturn("sess-1");
+        when(exchange.getProperty(CamelConstants.Properties.IS_MAIN_EXCHANGE, Boolean.class)).thenReturn(Boolean.TRUE);
+
+        long startTime = System.currentTimeMillis() - 5_000;
+        long exchangeStartTime = System.currentTimeMillis() - 2_000;
+
+        when(exchange.getProperty(CamelConstants.Properties.START_TIME_MS, Long.class)).thenReturn(startTime);
+        when(exchange.getProperty(CamelConstants.Properties.EXCHANGE_START_TIME_MS, Long.class)).thenReturn(exchangeStartTime);
+
+        Metadata metadata = mock(Metadata.class);
+        when(metadata.getDeploymentId()).thenReturn("dep-1");
+        when(metadataService.getMetadata(exchange)).thenReturn(Optional.of(metadata));
+
+        CamelDebuggerProperties props = mock(CamelDebuggerProperties.class, RETURNS_DEEP_STUBS);
+        when(props.getDeploymentInfo().getChainId()).thenReturn("chain-1");
+        when(props.getActualRuntimeProperties().calculateSessionLevel(exchange)).thenReturn(null);
+        when(propertiesService.getProperties(exchange)).thenReturn(props);
+
+        long before = System.currentTimeMillis();
+        List<LiveExchangeDTO> result = service.getTopLiveExchanges(10);
+        long after = System.currentTimeMillis();
+
+        assertEquals(1, result.size());
+        LiveExchangeDTO dto = result.getFirst();
+
+        assertEquals("ex-1", dto.getExchangeId());
+        assertEquals("dep-1", dto.getDeploymentId());
+        assertEquals("sess-1", dto.getSessionId());
+        assertEquals("chain-1", dto.getChainId());
+        assertEquals(startTime, dto.getSessionStartTime());
+        assertEquals(Boolean.TRUE, dto.getMain());
+
+        assertNotNull(dto.getSessionDuration());
+        assertTrue(dto.getSessionDuration() >= (before - startTime));
+        assertTrue(dto.getSessionDuration() <= (after - startTime));
+
+        assertNotNull(dto.getDuration());
+        assertTrue(dto.getDuration() >= (before - exchangeStartTime));
+        assertTrue(dto.getDuration() <= (after - exchangeStartTime));
+
+        verify(inflightRepository).browse(eq(10), eq(true));
+        verify(propertiesService).getProperties(exchange);
+        verify(metadataService).getMetadata(exchange);
+    }
+
+    @Test
+    void shouldSetNullDurationsWhenStartTimesAbsent() {
+        when(camelContext.getInflightRepository()).thenReturn(inflightRepository);
+
+        Exchange exchange = mock(Exchange.class);
+        InflightRepository.InflightExchange holder = mock(InflightRepository.InflightExchange.class);
+        when(holder.getExchange()).thenReturn(exchange);
+
+        when(inflightRepository.browse(eq(1), eq(true))).thenReturn(List.of(holder));
+
+        when(exchange.getExchangeId()).thenReturn("ex-1");
+        when(exchange.getProperty(CamelConstants.Properties.SESSION_ID, String.class)).thenReturn("sess-1");
+        when(exchange.getProperty(CamelConstants.Properties.IS_MAIN_EXCHANGE, Boolean.class)).thenReturn(Boolean.FALSE);
+
+        when(exchange.getProperty(CamelConstants.Properties.START_TIME_MS, Long.class)).thenReturn(null);
+        when(exchange.getProperty(CamelConstants.Properties.EXCHANGE_START_TIME_MS, Long.class)).thenReturn(null);
+
+        when(metadataService.getMetadata(exchange)).thenReturn(Optional.empty());
+
+        CamelDebuggerProperties props = mock(CamelDebuggerProperties.class, RETURNS_DEEP_STUBS);
+        when(props.getDeploymentInfo().getChainId()).thenReturn("chain-1");
+        when(props.getActualRuntimeProperties().calculateSessionLevel(exchange)).thenReturn(null);
+        when(propertiesService.getProperties(exchange)).thenReturn(props);
+
+        List<LiveExchangeDTO> result = service.getTopLiveExchanges(1);
+
+        assertEquals(1, result.size());
+        LiveExchangeDTO dto = result.getFirst();
+
+        assertEquals("ex-1", dto.getExchangeId());
+        assertNull(dto.getDeploymentId());
+        assertEquals("sess-1", dto.getSessionId());
+        assertEquals("chain-1", dto.getChainId());
+
+        assertNull(dto.getSessionStartTime());
+        assertNull(dto.getSessionDuration());
+        assertNull(dto.getDuration());
+        assertEquals(Boolean.FALSE, dto.getMain());
+    }
+
+    @Test
+    void shouldSetTerminatedExceptionWhenKillingExistingLiveExchange() {
+        when(camelContext.getInflightRepository()).thenReturn(inflightRepository);
+
+        Exchange exchange = mock(Exchange.class);
+        when(exchange.getExchangeId()).thenReturn("ex-1");
+
+        InflightRepository.InflightExchange holder = mock(InflightRepository.InflightExchange.class);
+        when(holder.getExchange()).thenReturn(exchange);
+
+        when(inflightRepository.browse()).thenReturn(List.of(holder));
+
+        service.killLiveExchangeById("dep-1", "ex-1");
+
+        ArgumentCaptor<Exception> captor = ArgumentCaptor.forClass(Exception.class);
+        verify(exchange).setException(captor.capture());
+
+        Exception ex = captor.getValue();
+        assertTrue(ex instanceof ChainExecutionTerminatedException);
+        assertEquals("Chain was interrupted manually", ex.getMessage());
+    }
+
+    @Test
+    void shouldThrowEntityNotFoundWhenNoLiveExchangeFound() {
+        when(camelContext.getInflightRepository()).thenReturn(inflightRepository);
+
+        Exchange exchange = mock(Exchange.class);
+        when(exchange.getExchangeId()).thenReturn("ex-other");
+
+        InflightRepository.InflightExchange holder = mock(InflightRepository.InflightExchange.class);
+        when(holder.getExchange()).thenReturn(exchange);
+
+        when(inflightRepository.browse()).thenReturn(List.of(holder));
+
+        EntityNotFoundException ex = assertThrows(
+                EntityNotFoundException.class,
+                () -> service.killLiveExchangeById("dep-777", "ex-1")
+        );
+
+        assertTrue(ex.getMessage().contains("dep-777"));
+        verify(exchange, never()).setException(any());
+    }
+}

--- a/src/test/java/org/qubership/integration/platform/engine/service/debugger/masking/MaskingServiceTest.java
+++ b/src/test/java/org/qubership/integration/platform/engine/service/debugger/masking/MaskingServiceTest.java
@@ -1,0 +1,235 @@
+/*
+ * Copyright 2024-2025 NetCracker Technology Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.qubership.integration.platform.engine.service.debugger.masking;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.ws.rs.NotSupportedException;
+import jakarta.ws.rs.core.MediaType;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.qubership.integration.platform.engine.errorhandling.LoggingMaskingException;
+import org.qubership.integration.platform.engine.model.SessionElementProperty;
+import org.qubership.integration.platform.engine.model.constants.CamelConstants;
+import org.qubership.integration.platform.engine.testutils.DisplayNameUtils;
+import org.qubership.integration.platform.engine.testutils.ObjectMappers;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@DisplayNameGeneration(DisplayNameUtils.ReplaceCamelCase.class)
+class MaskingServiceTest {
+
+    private MaskingService service(ObjectMapper mapper) {
+        return new MaskingService(mapper);
+    }
+
+    @Test
+    void shouldMaskJsonValuesAndArraysWhenJson() throws Exception {
+        ObjectMapper mapper = ObjectMappers.getObjectMapper();
+        MaskingService svc = service(mapper);
+
+        String json = """
+                {
+                  "password": "123",
+                  "user": "bob",
+                  "attrs": {
+                    "token": "abc",
+                    "keep": "ok"
+                  },
+                  "scopes": ["read","write"],
+                  "numbers": [1,2,3],
+                  "nestedArray": {
+                    "codes": ["x","y"],
+                    "objs": [
+                        {
+                          "password": "p1"
+                        },
+                        {
+                          "keep": "k"
+                        }
+                    ]
+                  }
+                }
+                """;
+
+        Set<String> fields = Set.of("password", "token", "codes");
+        String masked = svc.maskFields(json, fields, MediaType.APPLICATION_JSON_TYPE);
+
+        JsonNode root = mapper.readTree(masked);
+        assertEquals(CamelConstants.MASKING_TEMPLATE, root.get("password").asText());
+        assertEquals("bob", root.get("user").asText());
+        assertEquals(CamelConstants.MASKING_TEMPLATE, root.get("attrs").get("token").asText());
+        assertEquals("ok", root.get("attrs").get("keep").asText());
+
+        assertEquals("read", root.get("scopes").get(0).asText());
+        assertEquals(1, root.get("numbers").get(0).asInt());
+
+        assertEquals(CamelConstants.MASKING_TEMPLATE, root.get("nestedArray").get("codes").get(0).asText());
+        assertEquals(CamelConstants.MASKING_TEMPLATE, root.get("nestedArray").get("codes").get(1).asText());
+        assertEquals(CamelConstants.MASKING_TEMPLATE, root.get("nestedArray").get("objs").get(0).get("password").asText());
+        assertEquals("k", root.get("nestedArray").get("objs").get(1).get("keep").asText());
+    }
+
+    @Test
+    void shouldTreatJsonPatchAsJson() throws Exception {
+        ObjectMapper mapper = ObjectMappers.getObjectMapper();
+        MaskingService svc = service(mapper);
+
+        String json = "{\"token\":\"abc\",\"other\":\"v\"}";
+        MediaType jsonPatch = MediaType.valueOf("application/json-patch+json");
+        String masked = svc.maskFields(json, Set.of("token"), jsonPatch);
+
+        JsonNode root = mapper.readTree(masked);
+        assertEquals(CamelConstants.MASKING_TEMPLATE, root.get("token").asText());
+        assertEquals("v", root.get("other").asText());
+    }
+
+    @Test
+    void shouldWrapJsonErrorsWhenInvalidJson() {
+        ObjectMapper mapper = ObjectMappers.getObjectMapper();
+        MaskingService svc = service(mapper);
+
+        assertThrows(LoggingMaskingException.class, () ->
+                svc.maskFields("{bad}", Set.of("password"), MediaType.APPLICATION_JSON_TYPE)
+        );
+    }
+
+    @Test
+    void shouldMaskXmlElementsAndAttributesWhenXml() throws Exception {
+        ObjectMapper mapper = ObjectMappers.getObjectMapper();
+        MaskingService svc = service(mapper);
+
+        String xml = """
+                <?xml version="1.0" encoding="UTF-8"?>
+                <root token="abc">
+                  <user>bob</user>
+                  <password>123</password>
+                  <nested>
+                    <keep attr="ok">val</keep>
+                    <secret attr="hide">value</secret>
+                  </nested>
+                </root>
+                """;
+
+        String masked = svc.maskFields(xml, Set.of("password", "token", "secret", "attr"), MediaType.APPLICATION_XML_TYPE);
+
+        assertTrue(masked.contains("<password>" + CamelConstants.MASKING_TEMPLATE + "</password>"));
+        assertTrue(masked.contains("token=\"" + CamelConstants.MASKING_TEMPLATE + "\""));
+        assertTrue(masked.contains(
+                "<secret attr=\""
+                        + CamelConstants.MASKING_TEMPLATE
+                        + "\">"
+                        + CamelConstants.MASKING_TEMPLATE
+                        + "</secret>"
+        ));
+        assertTrue(masked.contains("attr=\"" + CamelConstants.MASKING_TEMPLATE + "\""));
+        assertTrue(masked.contains("<user>bob</user>"));
+    }
+
+    @Test
+    void shouldWrapXmlErrorsWhenInvalidXml() {
+        ObjectMapper mapper = ObjectMappers.getObjectMapper();
+        MaskingService svc = service(mapper);
+
+        String brokenXml = "<root><password>123</password>";
+        assertThrows(LoggingMaskingException.class, () ->
+                svc.maskFields(brokenXml, Set.of("password"), MediaType.APPLICATION_XML_TYPE)
+        );
+    }
+
+    @Test
+    void shouldMaskFormUrlencodedWithDecodedKeyMatch() throws Exception {
+        ObjectMapper mapper = ObjectMappers.getObjectMapper();
+        MaskingService svc = service(mapper);
+
+        String form = "password=abc&user=Bob&%74%6F%6B%65%6E=xyz";
+        String masked = svc.maskFields(form, Set.of("password", "token"), MediaType.valueOf("application/x-www-form-urlencoded"));
+
+        assertEquals("password=" + CamelConstants.MASKING_TEMPLATE + "&user=Bob&%74%6F%6B%65%6E=" + CamelConstants.MASKING_TEMPLATE, masked);
+    }
+
+    @Test
+    void shouldWrapFormUrlencodedErrorsOnBadPercent() {
+        ObjectMapper mapper = ObjectMappers.getObjectMapper();
+        MaskingService svc = service(mapper);
+
+        String form = "%ZZ=abc&user=Bob";
+        assertThrows(LoggingMaskingException.class, () ->
+                svc.maskFields(form, Set.of("user"), MediaType.valueOf("application/x-www-form-urlencoded"))
+        );
+    }
+
+    @Test
+    void shouldMaskMapValuesOnlyForExistingKeys() {
+        ObjectMapper mapper = ObjectMappers.getObjectMapper();
+        MaskingService svc = service(mapper);
+
+        Map<String, String> map = new HashMap<>();
+        map.put("password", "123");
+        map.put("user", "bob");
+
+        svc.maskFields(map, Set.of("password", "token"));
+
+        assertEquals(CamelConstants.MASKING_TEMPLATE, map.get("password"));
+        assertEquals("bob", map.get("user"));
+        assertFalse(map.containsKey("token"));
+    }
+
+    @Test
+    void shouldMaskPropertiesValuesViaSetValueOnlyForExistingKeys() {
+        ObjectMapper mapper = ObjectMappers.getObjectMapper();
+        MaskingService svc = service(mapper);
+
+        SessionElementProperty p1 = Mockito.mock(SessionElementProperty.class);
+        SessionElementProperty p2 = Mockito.mock(SessionElementProperty.class);
+
+        Map<String, SessionElementProperty> props = new HashMap<>();
+        props.put("secret", p1);
+        props.put("keep", p2);
+
+        svc.maskPropertiesFields(props, Set.of("secret", "missing"));
+
+        verify(p1, times(1)).setValue(CamelConstants.MASKING_TEMPLATE);
+        verify(p2, never()).setValue(any());
+    }
+
+    @Test
+    void shouldThrowNotSupportedWhenUnknownContentType() {
+        ObjectMapper mapper = ObjectMappers.getObjectMapper();
+        MaskingService svc = service(mapper);
+
+        assertThrows(NotSupportedException.class, () ->
+                svc.maskFields("abc", Set.of("x"), MediaType.TEXT_PLAIN_TYPE)
+        );
+    }
+
+    @Test
+    void shouldThrowNotSupportedWhenContentTypeNull() {
+        ObjectMapper mapper = ObjectMappers.getObjectMapper();
+        MaskingService svc = service(mapper);
+
+        assertThrows(NotSupportedException.class, () ->
+                svc.maskFields("{}", Set.of("x"), null)
+        );
+    }
+}

--- a/src/test/java/org/qubership/integration/platform/engine/service/debugger/util/PayloadExtractorTest.java
+++ b/src/test/java/org/qubership/integration/platform/engine/service/debugger/util/PayloadExtractorTest.java
@@ -1,0 +1,405 @@
+/*
+ * Copyright 2024-2025 NetCracker Technology Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.qubership.integration.platform.engine.service.debugger.util;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.enterprise.inject.Instance;
+import jakarta.ws.rs.NotSupportedException;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.support.http.HttpUtil;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.qubership.integration.platform.engine.camel.context.propagation.CamelExchangeContextPropagation;
+import org.qubership.integration.platform.engine.errorhandling.LoggingMaskingException;
+import org.qubership.integration.platform.engine.errorhandling.errorcode.ErrorCode;
+import org.qubership.integration.platform.engine.model.SessionElementProperty;
+import org.qubership.integration.platform.engine.model.constants.CamelConstants.Headers;
+import org.qubership.integration.platform.engine.service.debugger.masking.MaskingService;
+import org.qubership.integration.platform.engine.testutils.DisplayNameUtils;
+import org.qubership.integration.platform.engine.testutils.MockExchanges;
+import org.qubership.integration.platform.engine.util.ExchangeUtils;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@DisplayNameGeneration(DisplayNameUtils.ReplaceCamelCase.class)
+class PayloadExtractorTest {
+
+    private PayloadExtractor extractor(
+            MaskingService maskingService,
+            ObjectMapper mapper,
+            Instance<CamelExchangeContextPropagation> propagation
+    ) {
+        return new PayloadExtractor(maskingService, mapper, propagation);
+    }
+
+    private Instance<CamelExchangeContextPropagation> instanceWith(CamelExchangeContextPropagation propagation) {
+        @SuppressWarnings("unchecked")
+        Instance<CamelExchangeContextPropagation> inst = mock(Instance.class);
+        when(inst.isAmbiguous()).thenReturn(false);
+        when(inst.stream()).thenReturn(Stream.of(propagation));
+        return inst;
+    }
+
+    private Instance<CamelExchangeContextPropagation> instanceEmpty() {
+        @SuppressWarnings("unchecked")
+        Instance<CamelExchangeContextPropagation> inst = mock(Instance.class);
+        when(inst.isAmbiguous()).thenReturn(false);
+        when(inst.stream()).thenReturn(Stream.empty());
+        return inst;
+    }
+
+    private Map<String, Object> attachHeaders(Exchange ex) {
+        Message msg = MockExchanges.getMessage(ex);
+        Map<String, Object> headers = new HashMap<>();
+        when(msg.getHeaders()).thenReturn(headers);
+        return headers;
+    }
+
+    @Test
+    void shouldExtractHeadersAsStringsWhenCalled() {
+        Exchange ex = MockExchanges.withMessage();
+        Map<String, Object> headers = attachHeaders(ex);
+        headers.put("a", 1);
+        headers.put("b", null);
+
+        MaskingService masking = mock(MaskingService.class);
+        PayloadExtractor pe = extractor(masking, mock(ObjectMapper.class), instanceEmpty());
+
+        Map<String, String> out = pe.extractHeadersForLogging(ex, Set.of("a"), false);
+
+        assertEquals("1", out.get("a"));
+        assertEquals("", out.get("b"));
+        verifyNoInteractions(masking);
+    }
+
+    @Test
+    void shouldMaskHeadersWhenMaskingEnabled() {
+        Exchange ex = MockExchanges.withMessage();
+        Map<String, Object> headers = attachHeaders(ex);
+        headers.put("password", "123");
+        headers.put("user", "bob");
+
+        MaskingService masking = mock(MaskingService.class);
+        PayloadExtractor pe = extractor(masking, mock(ObjectMapper.class), instanceEmpty());
+
+        Map<String, String> out = pe.extractHeadersForLogging(ex, Set.of("password"), true);
+
+        assertEquals("123", out.get("password"));
+        assertEquals("bob", out.get("user"));
+        verify(masking).maskFields(anyMap(), eq(Set.of("password")));
+    }
+
+    @Test
+    void shouldMaskBodyWhenMaskingEnabledAndContentTypePresent() throws Exception {
+        Exchange ex = MockExchanges.withMessage();
+        Map<String, Object> headers = attachHeaders(ex);
+        headers.put(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
+
+        MaskingService masking = mock(MaskingService.class);
+        PayloadExtractor pe = extractor(masking, mock(ObjectMapper.class), instanceEmpty());
+
+        try (MockedStatic<MessageHelper> mh = Mockito.mockStatic(MessageHelper.class)) {
+            mh.when(() -> MessageHelper.extractBody(ex)).thenReturn("{\"password\":\"123\"}");
+            when(masking.maskFields(anyString(), eq(Set.of("password")), eq(MediaType.APPLICATION_JSON_TYPE)))
+                    .thenReturn("{\"password\":\"******\"}");
+
+            String out = pe.extractBodyForLogging(ex, Set.of("password"), true);
+
+            assertEquals("{\"password\":\"******\"}", out);
+            verify(masking).maskFields("{\"password\":\"123\"}", Set.of("password"), MediaType.APPLICATION_JSON_TYPE);
+        }
+    }
+
+    @Test
+    void shouldReturnBodyAsIsWhenMaskingThrowsLoggingMaskingException() throws Exception {
+        Exchange ex = MockExchanges.withMessage();
+        Map<String, Object> headers = attachHeaders(ex);
+        headers.put(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
+
+        MaskingService masking = mock(MaskingService.class);
+        PayloadExtractor pe = extractor(masking, mock(ObjectMapper.class), instanceEmpty());
+
+        try (MockedStatic<MessageHelper> mh = Mockito.mockStatic(MessageHelper.class)) {
+            mh.when(() -> MessageHelper.extractBody(ex)).thenReturn("{\"password\":\"123\"}");
+            when(masking.maskFields(anyString(), anySet(), any(MediaType.class)))
+                    .thenThrow(new LoggingMaskingException("x", new RuntimeException("y")));
+
+            String out = pe.extractBodyForLogging(ex, Set.of("password"), true);
+
+            assertEquals("{\"password\":\"123\"}", out);
+        }
+    }
+
+    @Test
+    void shouldReturnBodyAsIsWhenMaskingThrowsNotSupportedException() throws Exception {
+        Exchange ex = MockExchanges.withMessage();
+        Map<String, Object> headers = attachHeaders(ex);
+        headers.put(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON);
+
+        MaskingService masking = mock(MaskingService.class);
+        PayloadExtractor pe = extractor(masking, mock(ObjectMapper.class), instanceEmpty());
+
+        try (MockedStatic<MessageHelper> mh = Mockito.mockStatic(MessageHelper.class)) {
+            mh.when(() -> MessageHelper.extractBody(ex)).thenReturn("{\"password\":\"123\"}");
+            when(masking.maskFields(anyString(), anySet(), any(MediaType.class)))
+                    .thenThrow(new NotSupportedException("nope"));
+
+            String out = pe.extractBodyForLogging(ex, Set.of("password"), true);
+
+            assertEquals("{\"password\":\"123\"}", out);
+        }
+    }
+
+    @Test
+    void shouldReturnBodyAsIsWhenContentTypeMissing() throws Exception {
+        Exchange ex = MockExchanges.withMessage();
+        attachHeaders(ex);
+
+        MaskingService masking = mock(MaskingService.class);
+        PayloadExtractor pe = extractor(masking, mock(ObjectMapper.class), instanceEmpty());
+
+        try (MockedStatic<MessageHelper> mh = Mockito.mockStatic(MessageHelper.class)) {
+            mh.when(() -> MessageHelper.extractBody(ex)).thenReturn("{\"password\":\"123\"}");
+
+            String out = pe.extractBodyForLogging(ex, Set.of("password"), true);
+
+            assertEquals("{\"password\":\"123\"}", out);
+            verifyNoInteractions(masking);
+        }
+    }
+
+    @Test
+    void shouldMaskExchangePropertiesWhenMaskingEnabled() throws Exception {
+        Exchange ex = MockExchanges.withMessage();
+        attachHeaders(ex);
+
+        MaskingService masking = mock(MaskingService.class);
+        PayloadExtractor pe = extractor(masking, mock(ObjectMapper.class), instanceEmpty());
+
+        SessionElementProperty secretProp = mock(SessionElementProperty.class);
+        SessionElementProperty keepProp = mock(SessionElementProperty.class);
+
+        when(secretProp.getValue()).thenReturn("{\"secret\":\"1\"}");
+        when(keepProp.getValue()).thenReturn("{\"keep\":\"2\"}");
+
+        Map<String, SessionElementProperty> props = new HashMap<>();
+        props.put("secret", secretProp);
+        props.put("keep", keepProp);
+
+        when(masking.maskJSON(eq("{\"secret\":\"1\"}"), eq(Set.of("secret")))).thenReturn("{\"secret\":\"******\"}");
+        when(masking.maskJSON(eq("{\"keep\":\"2\"}"), eq(Set.of("secret")))).thenReturn("{\"keep\":\"2\"}");
+
+        try (MockedStatic<ExchangeUtils> eu = Mockito.mockStatic(ExchangeUtils.class)) {
+            eu.when(() -> ExchangeUtils.prepareExchangePropertiesForLogging(ex)).thenReturn(props);
+
+            Map<String, SessionElementProperty> out = pe.extractExchangePropertiesForLogging(ex, Set.of("secret"), true);
+
+            assertSame(props, out);
+
+            verify(masking).maskPropertiesFields(props, Set.of("secret"));
+            verify(secretProp).setValue(anyString());
+            verify(keepProp).setValue(anyString());
+
+            verify(secretProp).setValue("{\"secret\":\"******\"}");
+            verify(keepProp).setValue("{\"keep\":\"2\"}");
+        }
+    }
+
+    @Test
+    void shouldSkipMaskingExchangePropertiesWhenMaskingDisabled() {
+        Exchange ex = MockExchanges.withMessage();
+        attachHeaders(ex);
+
+        MaskingService masking = mock(MaskingService.class);
+        PayloadExtractor pe = extractor(masking, mock(ObjectMapper.class), instanceEmpty());
+
+        Map<String, SessionElementProperty> props = new HashMap<>();
+        props.put("a", mock(SessionElementProperty.class));
+
+        try (MockedStatic<ExchangeUtils> eu = Mockito.mockStatic(ExchangeUtils.class)) {
+            eu.when(() -> ExchangeUtils.prepareExchangePropertiesForLogging(ex)).thenReturn(props);
+
+            Map<String, SessionElementProperty> out = pe.extractExchangePropertiesForLogging(ex, Set.of("x"), false);
+
+            assertSame(props, out);
+            verifyNoInteractions(masking);
+        }
+    }
+
+    @Test
+    void shouldIgnoreInvalidJsonInPropertyWhenMaskJsonThrows() throws Exception {
+        Exchange ex = MockExchanges.withMessage();
+        attachHeaders(ex);
+
+        MaskingService masking = mock(MaskingService.class);
+        PayloadExtractor pe = extractor(masking, mock(ObjectMapper.class), instanceEmpty());
+
+        SessionElementProperty p1 = mock(SessionElementProperty.class);
+        when(p1.getValue()).thenReturn("bad-json");
+
+        Map<String, SessionElementProperty> props = new HashMap<>();
+        props.put("a", p1);
+
+        try (MockedStatic<ExchangeUtils> eu = Mockito.mockStatic(ExchangeUtils.class)) {
+            eu.when(() -> ExchangeUtils.prepareExchangePropertiesForLogging(ex)).thenReturn(props);
+            when(masking.maskJSON(eq("bad-json"), eq(Set.of("secret")))).thenThrow(new JsonProcessingException("x") {});
+
+            Map<String, SessionElementProperty> out = pe.extractExchangePropertiesForLogging(ex, Set.of("secret"), true);
+
+            assertSame(props, out);
+            verify(masking).maskPropertiesFields(props, Set.of("secret"));
+            verify(masking).maskJSON("bad-json", Set.of("secret"));
+            verify(p1, never()).setValue(anyString());
+        }
+    }
+
+    @Test
+    void shouldExtractContextWhenPropagationPresent() {
+        MaskingService masking = mock(MaskingService.class);
+        ObjectMapper mapper = mock(ObjectMapper.class);
+
+        CamelExchangeContextPropagation propagation = mock(CamelExchangeContextPropagation.class);
+        Map<String, String> ctx = new HashMap<>();
+        ctx.put("token", "abc");
+        when(propagation.buildContextSnapshotForSessions()).thenReturn(ctx);
+
+        PayloadExtractor pe = extractor(masking, mapper, instanceWith(propagation));
+
+        Map<String, String> out = pe.extractContextForLogging(Set.of("token"), true);
+
+        assertEquals("abc", out.get("token"));
+        verify(masking).maskFields(ctx, Set.of("token"));
+    }
+
+    @Test
+    void shouldReturnEmptyContextWhenPropagationAbsent() {
+        MaskingService masking = mock(MaskingService.class);
+        PayloadExtractor pe = extractor(masking, mock(ObjectMapper.class), instanceEmpty());
+
+        Map<String, String> out = pe.extractContextForLogging(Set.of("token"), true);
+
+        assertTrue(out.isEmpty());
+    }
+
+    @Test
+    void shouldConvertToJsonWhenMapperWorks() throws Exception {
+        ObjectMapper mapper = mock(ObjectMapper.class);
+        PayloadExtractor pe = extractor(mock(MaskingService.class), mapper, instanceEmpty());
+
+        Map<String, Object> map = new HashMap<>();
+        map.put("a", 1);
+
+        when(mapper.writeValueAsString(map)).thenReturn("{\"a\":1}");
+
+        assertEquals("{\"a\":1}", pe.convertToJson(map));
+    }
+
+    @Test
+    void shouldReturnNullWhenConvertToJsonFails() throws Exception {
+        ObjectMapper mapper = mock(ObjectMapper.class);
+        PayloadExtractor pe = extractor(mock(MaskingService.class), mapper, instanceEmpty());
+
+        Map<String, Object> map = new HashMap<>();
+        map.put("a", 1);
+
+        when(mapper.writeValueAsString(map)).thenThrow(new JsonProcessingException("x") {});
+
+        assertNull(pe.convertToJson(map));
+    }
+
+    @Test
+    void shouldReturnNullWhenConvertToJsonInputNull() {
+        PayloadExtractor pe = extractor(mock(MaskingService.class), mock(ObjectMapper.class), instanceEmpty());
+        assertNull(pe.convertToJson(null));
+    }
+
+    @Test
+    void shouldGetResponseCodeWhenHeaderPresent() {
+        Map<String, Object> headers = new HashMap<>();
+        headers.put(Headers.CAMEL_HTTP_RESPONSE_CODE, 201);
+        assertEquals(201, PayloadExtractor.getResponseCode(headers));
+    }
+
+    @Test
+    void shouldReturnNullWhenResponseCodeHeaderAbsent() {
+        assertNull(PayloadExtractor.getResponseCode(new HashMap<>()));
+    }
+
+    @Test
+    void shouldReturnErrorCodeHttpWhenExceptionPresent() {
+        Exchange ex = MockExchanges.withMessage();
+        attachHeaders(ex);
+
+        try (MockedStatic<ErrorCode> ec = Mockito.mockStatic(ErrorCode.class)) {
+            ec.when(() -> ErrorCode.match(any(Exception.class))).thenReturn(ErrorCode.UNEXPECTED_BUSINESS_ERROR);
+
+            int code = PayloadExtractor.getServletResponseCode(ex, new RuntimeException("x"));
+
+            assertEquals(ErrorCode.UNEXPECTED_BUSINESS_ERROR.getHttpErrorCode(), code);
+        }
+    }
+
+    @Test
+    void shouldUseHttpUtilWhenExceptionNull() {
+        Exchange ex = MockExchanges.withMessage();
+        attachHeaders(ex);
+
+        Message msg = MockExchanges.getMessage(ex);
+        when(msg.getBody()).thenReturn("body");
+
+        try (MockedStatic<HttpUtil> hu = Mockito.mockStatic(HttpUtil.class)) {
+            hu.when(() -> HttpUtil.determineResponseCode(eq(ex), eq("body"))).thenReturn(202);
+
+            int code = PayloadExtractor.getServletResponseCode(ex, null);
+
+            assertEquals(202, code);
+            hu.verify(() -> HttpUtil.determineResponseCode(eq(ex), eq("body")));
+        }
+    }
+
+    @Test
+    void shouldExtractContentTypeWhenHeaderPresent() {
+        Exchange ex = MockExchanges.withMessage();
+        Map<String, Object> headers = attachHeaders(ex);
+        headers.put(HttpHeaders.CONTENT_TYPE, "application/json");
+
+        MediaType ct = PayloadExtractor.extractContentType(ex);
+
+        assertNotNull(ct);
+        assertTrue(MediaType.APPLICATION_JSON_TYPE.isCompatible(ct));
+    }
+
+    @Test
+    void shouldReturnNullWhenContentTypeMissing() {
+        Exchange ex = MockExchanges.withMessage();
+        attachHeaders(ex);
+        assertNull(PayloadExtractor.extractContentType(ex));
+    }
+}

--- a/src/test/java/org/qubership/integration/platform/engine/testutils/ObjectMappers.java
+++ b/src/test/java/org/qubership/integration/platform/engine/testutils/ObjectMappers.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2024-2025 NetCracker Technology Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.qubership.integration.platform.engine.testutils;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.rabbitmq.client.LongString;
+import org.postgresql.jdbc.PgArray;
+import org.qubership.integration.platform.engine.camel.components.rabbitmq.serializers.LongStringSerializer;
+import org.qubership.integration.platform.engine.camel.processors.serializers.PgArraySerializer;
+
+public final class ObjectMappers {
+
+    public static ObjectMapper getObjectMapper() {
+        return buildObjectMapper();
+    }
+
+
+    private static ObjectMapper buildObjectMapper() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        objectMapper.enable(SerializationFeature.INDENT_OUTPUT);
+        objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+
+        SimpleModule serializeModule = new SimpleModule();
+        serializeModule.addSerializer(LongString.class, new LongStringSerializer(LongString.class));
+        serializeModule.addSerializer(PgArray.class, new PgArraySerializer(PgArray.class));
+
+        objectMapper.registerModule(serializeModule);
+        return objectMapper;
+    }
+}


### PR DESCRIPTION
Unit tests + separate object mappers mock

- MaskingService
- PayloadExtractor
- CheckpointSessionService
- DeploymentsUpdateService
- IdempotencyRecordService
- LiveExchangesService

Separate mock for objectMapper
