### PR TITLE
test: #31 Unit tests + adjust exchange mocks

### DIFF
--- a/src/test/java/org/qubership/integration/platform/engine/camel/components/directvm/ChainBlockingProducerTest.java
+++ b/src/test/java/org/qubership/integration/platform/engine/camel/components/directvm/ChainBlockingProducerTest.java
@@ -1,0 +1,131 @@
+package org.qubership.integration.platform.engine.camel.components.directvm;
+
+import org.apache.camel.AsyncCallback;
+import org.apache.camel.AsyncProcessor;
+import org.apache.camel.Exchange;
+import org.apache.camel.Processor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.qubership.integration.platform.engine.testutils.DisplayNameUtils;
+import org.qubership.integration.platform.engine.testutils.MockExchanges;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameUtils.ReplaceCamelCase.class)
+class ChainBlockingProducerTest {
+
+    @Mock
+    ChainEndpoint endpoint;
+    @Mock
+    ChainConsumer consumer;
+
+    @Mock
+    Processor processor;
+    @Mock
+    AsyncProcessor asyncProcessor;
+    @Mock
+    Exchange exchange;
+
+    private ChainBlockingProducer producer;
+
+    @BeforeEach
+    void setUp() {
+        producer = new ChainBlockingProducer(endpoint);
+        exchange = MockExchanges.withDefaultCamelContext();
+    }
+
+    @Test
+    void shouldDelegateToConsumerProcessorWhenProcessSyncAndConsumerAvailable() throws Exception {
+        doReturn(consumer).when(endpoint).getConsumer();
+        when(consumer.getProcessor()).thenReturn(processor);
+
+        producer.process(exchange);
+
+        verify(processor).process(exchange);
+    }
+
+    @Test
+    void shouldThrowWhenNoConsumerAndFailIfNoConsumersTrueInSyncProcess() {
+        when(endpoint.getConsumer()).thenReturn(null);
+        when(endpoint.isFailIfNoConsumers()).thenReturn(true);
+
+        assertThrows(ChainConsumerNotAvailableException.class, () -> producer.process(exchange));
+    }
+
+    @Test
+    void shouldAwaitAndThenUseConsumerWhenNoConsumerInitiallyAndFailIfNoConsumersFalse() throws Exception {
+        when(endpoint.getConsumer()).thenReturn(null, consumer);
+        when(endpoint.isFailIfNoConsumers()).thenReturn(false);
+        when(endpoint.getTimeout()).thenReturn(30_000L);
+
+        when(consumer.getProcessor()).thenReturn(processor);
+
+        producer.process(exchange);
+
+        verify(processor).process(exchange);
+        verify(endpoint, atLeast(2)).getConsumer();
+    }
+
+    @Test
+    void shouldThrowWhenNoConsumerAfterAwaitInSyncProcess() {
+        when(endpoint.getConsumer()).thenReturn(null);
+        when(endpoint.isFailIfNoConsumers()).thenReturn(false);
+        when(endpoint.getTimeout()).thenReturn(0L);
+
+        assertThrows(ChainConsumerNotAvailableException.class, () -> producer.process(exchange));
+    }
+
+    @Test
+    void shouldDelegateToConsumerAsyncProcessorWhenProcessAsyncAndConsumerAvailable() {
+        AsyncCallback callback = mock(AsyncCallback.class);
+
+        when(endpoint.getConsumer()).thenReturn(consumer);
+        when(consumer.getAsyncProcessor()).thenReturn(asyncProcessor);
+        when(asyncProcessor.process(exchange, callback)).thenReturn(false);
+
+        boolean result = producer.process(exchange, callback);
+
+        assertFalse(result);
+        assertNull(exchange.getException());
+        verify(asyncProcessor).process(exchange, callback);
+    }
+
+    @Test
+    void shouldSetExceptionAndCompleteCallbackWhenAsyncProcessorThrows() {
+        var exchange = MockExchanges.withDefaultCamelContext();
+        AsyncCallback callback = mock(AsyncCallback.class);
+
+        when(endpoint.getConsumer()).thenReturn(consumer);
+        when(consumer.getAsyncProcessor()).thenReturn(asyncProcessor);
+
+        RuntimeException boom = new RuntimeException("boom");
+        when(asyncProcessor.process(exchange, callback)).thenThrow(boom);
+
+        boolean result = producer.process(exchange, callback);
+
+        assertTrue(result);
+        assertSame(boom, exchange.getException());
+        verify(callback).done(true);
+    }
+
+    @Test
+    void shouldSetExceptionAndCompleteCallbackWhenNoConsumerAndFailIfNoConsumersTrueInAsyncProcess() {
+        AsyncCallback callback = mock(AsyncCallback.class);
+
+        when(endpoint.getConsumer()).thenReturn(null);
+        when(endpoint.isFailIfNoConsumers()).thenReturn(true);
+
+        boolean result = producer.process(exchange, callback);
+
+        assertTrue(result);
+        assertNotNull(exchange.getException());
+        assertInstanceOf(ChainConsumerNotAvailableException.class, exchange.getException());
+        verify(callback).done(true);
+    }
+}

--- a/src/test/java/org/qubership/integration/platform/engine/camel/components/directvm/ChainComponentTest.java
+++ b/src/test/java/org/qubership/integration/platform/engine/camel/components/directvm/ChainComponentTest.java
@@ -1,0 +1,141 @@
+package org.qubership.integration.platform.engine.camel.components.directvm;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.qubership.integration.platform.engine.testutils.DisplayNameUtils;
+
+import java.lang.reflect.Field;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentMap;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameUtils.ReplaceCamelCase.class)
+class ChainComponentTest {
+
+    private ChainComponent component;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        clearConsumersStaticMap();
+        component = new ChainComponent();
+        component.setCamelContext(new DefaultCamelContext());
+    }
+
+    @Test
+    void shouldReturnNullWhenNoConsumersRegistered() {
+        ChainEndpoint endpoint = endpoint("cip-chain:routeA");
+
+        assertNull(component.getConsumer(endpoint));
+    }
+
+    @Test
+    void shouldReturnLastConsumerWhenMultipleConsumersAdded() {
+        ChainEndpoint endpoint = endpoint("cip-chain:routeA");
+
+        ChainConsumer c1 = mock(ChainConsumer.class);
+        ChainConsumer c2 = mock(ChainConsumer.class);
+
+        component.addConsumer(endpoint, c1);
+        component.addConsumer(endpoint, c2);
+
+        assertSame(c2, component.getConsumer(endpoint));
+    }
+
+    @Test
+    void shouldUseEndpointUriWithoutParametersAsConsumerKey() {
+        ChainEndpoint endpointWithQuery1 = endpoint("cip-chain:routeA?x=1");
+        ChainEndpoint endpointWithQuery2 = endpoint("cip-chain:routeA?y=2");
+
+        ChainConsumer c1 = mock(ChainConsumer.class);
+        component.addConsumer(endpointWithQuery1, c1);
+
+        assertSame(c1, component.getConsumer(endpointWithQuery2));
+    }
+
+    @Test
+    void shouldRemoveConsumerAndKeepOthers() {
+        ChainEndpoint endpoint = endpoint("cip-chain:routeA");
+
+        ChainConsumer c1 = mock(ChainConsumer.class);
+        ChainConsumer c2 = mock(ChainConsumer.class);
+
+        component.addConsumer(endpoint, c1);
+        component.addConsumer(endpoint, c2);
+
+        component.removeConsumer(endpoint, c2);
+        assertSame(c1, component.getConsumer(endpoint));
+
+        component.removeConsumer(endpoint, c1);
+        assertNull(component.getConsumer(endpoint));
+    }
+
+    @Test
+    void shouldNotFailWhenRemoveConsumerAndNoConsumersRegistered() {
+        ChainEndpoint endpoint = endpoint("cip-chain:routeA");
+
+        assertDoesNotThrow(() -> component.removeConsumer(endpoint, mock(ChainConsumer.class)));
+        assertNull(component.getConsumer(endpoint));
+    }
+
+    @Test
+    void shouldCreateEndpointWithComponentDefaultsWhenNoParametersProvided() throws Exception {
+        component.setBlock(false);
+        component.setTimeout(1234L);
+        component.setPropagateProperties(false);
+
+        Endpoint ep = component.createEndpoint("cip-chain:routeA", "routeA", new HashMap<>());
+
+        assertInstanceOf(ChainEndpoint.class, ep);
+        ChainEndpoint chainEndpoint = (ChainEndpoint) ep;
+
+        assertEquals("cip-chain:routeA", chainEndpoint.getEndpointUri());
+        assertFalse(chainEndpoint.isBlock());
+        assertEquals(1234L, chainEndpoint.getTimeout());
+        assertFalse(chainEndpoint.isPropagateProperties());
+    }
+
+    @Test
+    void shouldCreateEndpointAndOverrideDefaultsWithParameters() throws Exception {
+        component.setBlock(true);
+        component.setTimeout(30000L);
+        component.setPropagateProperties(true);
+
+        Map<String, Object> params = Map.of(
+                "block", false,
+                "timeout", 10_000L,
+                "propagateProperties", false
+        );
+
+        Endpoint ep = component.createEndpoint("cip-chain:routeA", "routeA", new HashMap<>(params));
+
+        assertInstanceOf(ChainEndpoint.class, ep);
+        ChainEndpoint chainEndpoint = (ChainEndpoint) ep;
+
+        assertFalse(chainEndpoint.isBlock());
+        assertEquals(10_000L, chainEndpoint.getTimeout());
+        assertFalse(chainEndpoint.isPropagateProperties());
+    }
+
+    private ChainEndpoint endpoint(String uri) {
+        return new ChainEndpoint(uri, component);
+    }
+
+    @SuppressWarnings("unchecked")
+    private void clearConsumersStaticMap() throws Exception {
+        Field f = ChainComponent.class.getDeclaredField("CONSUMERS");
+        f.setAccessible(true);
+        ConcurrentMap<String, List<ChainConsumer>> map =
+                (ConcurrentMap<String, List<ChainConsumer>>) f.get(null);
+        map.clear();
+    }
+}

--- a/src/test/java/org/qubership/integration/platform/engine/camel/components/directvm/ChainConsumerTest.java
+++ b/src/test/java/org/qubership/integration/platform/engine/camel/components/directvm/ChainConsumerTest.java
@@ -1,0 +1,99 @@
+package org.qubership.integration.platform.engine.camel.components.directvm;
+
+import org.apache.camel.Processor;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.qubership.integration.platform.engine.testutils.DisplayNameUtils;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.concurrent.ConcurrentMap;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameUtils.ReplaceCamelCase.class)
+class ChainConsumerTest {
+
+    private ChainComponent component;
+    private ChainEndpoint endpoint;
+    private Processor processor;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        clearConsumersStaticMap();
+
+        component = new ChainComponent();
+        component.setCamelContext(new DefaultCamelContext());
+
+        endpoint = new ChainEndpoint("cip-chain:routeA", component);
+        processor = mock(Processor.class);
+    }
+
+    @Test
+    void shouldRegisterConsumerInComponentWhenStarted() {
+        ChainConsumer consumer = new ChainConsumer(endpoint, processor);
+
+        consumer.start();
+
+        assertSame(consumer, component.getConsumer(endpoint));
+    }
+
+    @Test
+    void shouldUnregisterConsumerInComponentWhenStopped() {
+        ChainConsumer consumer = new ChainConsumer(endpoint, processor);
+
+        consumer.start();
+        assertSame(consumer, component.getConsumer(endpoint));
+
+        consumer.stop();
+
+        assertNull(component.getConsumer(endpoint));
+    }
+
+    @Test
+    void shouldUnregisterConsumerInComponentWhenSuspended() {
+        ChainConsumer consumer = new ChainConsumer(endpoint, processor);
+
+        consumer.start();
+        assertSame(consumer, component.getConsumer(endpoint));
+
+        consumer.suspend();
+
+        assertNull(component.getConsumer(endpoint));
+    }
+
+    @Test
+    void shouldRegisterConsumerInComponentWhenResumed() {
+        ChainConsumer consumer = new ChainConsumer(endpoint, processor);
+
+        consumer.start();
+        consumer.suspend();
+        assertNull(component.getConsumer(endpoint));
+
+        consumer.resume();
+
+        assertSame(consumer, component.getConsumer(endpoint));
+    }
+
+    @Test
+    void shouldReturnChainEndpointWhenGetEndpointCalled() {
+        ChainConsumer consumer = new ChainConsumer(endpoint, processor);
+
+        assertSame(endpoint, consumer.getEndpoint());
+    }
+
+    @SuppressWarnings("unchecked")
+    private void clearConsumersStaticMap() throws Exception {
+        Field f = ChainComponent.class.getDeclaredField("CONSUMERS");
+        f.setAccessible(true);
+        ConcurrentMap<String, List<ChainConsumer>> map =
+                (ConcurrentMap<String, List<ChainConsumer>>) f.get(null);
+        map.clear();
+    }
+}

--- a/src/test/java/org/qubership/integration/platform/engine/camel/components/directvm/ChainEndpointTest.java
+++ b/src/test/java/org/qubership/integration/platform/engine/camel/components/directvm/ChainEndpointTest.java
@@ -1,0 +1,103 @@
+package org.qubership.integration.platform.engine.camel.components.directvm;
+
+import org.apache.camel.Consumer;
+import org.apache.camel.Processor;
+import org.apache.camel.Producer;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.qubership.integration.platform.engine.testutils.DisplayNameUtils;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameUtils.ReplaceCamelCase.class)
+class ChainEndpointTest {
+
+    private ChainComponent component;
+    private ChainEndpoint endpoint;
+
+    @BeforeEach
+    void setUp() {
+        component = spy(new ChainComponent());
+        component.setCamelContext(new DefaultCamelContext());
+
+        endpoint = new ChainEndpoint("cip-chain:routeA", component);
+    }
+
+    @Test
+    void shouldReturnChainComponentFromGetComponent() {
+        assertSame(component, endpoint.getComponent());
+    }
+
+    @Test
+    void shouldCreateBlockingProducerWhenBlockTrue() throws Exception {
+        endpoint.setBlock(true);
+
+        Producer producer = endpoint.createProducer();
+
+        assertInstanceOf(ChainBlockingProducer.class, producer);
+    }
+
+    @Test
+    void shouldCreateNonBlockingProducerWhenBlockFalse() throws Exception {
+        endpoint.setBlock(false);
+
+        Producer producer = endpoint.createProducer();
+
+        assertInstanceOf(ChainProducer.class, producer);
+    }
+
+    @Test
+    void shouldCreateChainConsumerWithWrappedProcessorWhenCreateConsumer() throws Exception {
+        Processor processor = mock(Processor.class);
+
+        Consumer consumer = endpoint.createConsumer(processor);
+
+        assertNotNull(consumer);
+        assertInstanceOf(ChainConsumer.class, consumer);
+    }
+
+    @Test
+    void shouldGetConsumerFromComponent() {
+        ChainConsumer expected = mock(ChainConsumer.class);
+        doReturn(expected).when(component).getConsumer(endpoint);
+
+        ChainConsumer actual = endpoint.getConsumer();
+
+        assertSame(expected, actual);
+    }
+
+    @Test
+    void shouldReturnComponentHeaderFilterStrategyWhenEndpointHeaderFilterStrategyNull() {
+        var componentStrategy = mock(org.apache.camel.spi.HeaderFilterStrategy.class);
+        component.setHeaderFilterStrategy(componentStrategy);
+
+        assertSame(componentStrategy, endpoint.getHeaderFilterStrategy());
+    }
+
+    @Test
+    void shouldReturnEndpointHeaderFilterStrategyWhenSetOnEndpoint() {
+        var endpointStrategy = mock(org.apache.camel.spi.HeaderFilterStrategy.class);
+        endpoint.setHeaderFilterStrategy(endpointStrategy);
+
+        assertSame(endpointStrategy, endpoint.getHeaderFilterStrategy());
+    }
+
+    @Test
+    void shouldSetAndGetTimeoutBlockFailIfNoConsumersAndPropagateProperties() {
+        endpoint.setTimeout(42L);
+        endpoint.setBlock(false);
+        endpoint.setFailIfNoConsumers(false);
+        endpoint.setPropagateProperties(false);
+
+        assertEquals(42L, endpoint.getTimeout());
+        assertFalse(endpoint.isBlock());
+        assertFalse(endpoint.isFailIfNoConsumers());
+        assertFalse(endpoint.isPropagateProperties());
+    }
+}

--- a/src/test/java/org/qubership/integration/platform/engine/camel/components/directvm/ChainProcessorTest.java
+++ b/src/test/java/org/qubership/integration/platform/engine/camel/components/directvm/ChainProcessorTest.java
@@ -1,0 +1,178 @@
+package org.qubership.integration.platform.engine.camel.components.directvm;
+
+import org.apache.camel.AsyncCallback;
+import org.apache.camel.AsyncProcessor;
+import org.apache.camel.CamelContext;
+import org.apache.camel.Exchange;
+import org.apache.camel.ExchangePattern;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.support.DefaultExchange;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.qubership.integration.platform.engine.model.constants.CamelConstants;
+import org.qubership.integration.platform.engine.testutils.DisplayNameUtils;
+
+import java.util.concurrent.CompletableFuture;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameUtils.ReplaceCamelCase.class)
+class ChainProcessorTest {
+
+    private ChainComponent component;
+    private CamelContext endpointContext;
+    private ChainEndpoint endpoint;
+
+    @BeforeEach
+    void setUp() {
+        component = new ChainComponent();
+        endpointContext = new DefaultCamelContext();
+        component.setCamelContext(endpointContext);
+        endpoint = new ChainEndpoint("cip-chain:routeA", component);
+    }
+
+    @Test
+    void shouldSetChainCallTriggeredSessionToTrueDuringProcessingAndRestoreAfterDoneWhenPreviouslyFalse() {
+        Exchange exchange = new DefaultExchange(new DefaultCamelContext(), ExchangePattern.InOut);
+        exchange.getMessage().setBody("in");
+        exchange.setProperty(CamelConstants.Properties.IS_CHAIN_CALL_TRIGGERED_SESSION, false);
+
+        AsyncProcessor delegate = asyncProcessor((ex, cb) -> {
+            assertSame(endpointContext, ex.getContext());
+            assertSame(endpoint, ex.getFromEndpoint());
+
+            assertEquals(true, ex.getProperty(
+                    CamelConstants.Properties.IS_CHAIN_CALL_TRIGGERED_SESSION, Boolean.class));
+
+            ex.getMessage().setBody("changed");
+            cb.done(true);
+            return true;
+        });
+
+        ChainProcessor processor = new ChainProcessor(delegate, endpoint);
+
+        CapturingCallback callback = new CapturingCallback();
+        boolean result = processor.process(exchange, callback);
+
+        assertTrue(result);
+        assertEquals(true, callback.doneValue);
+
+        assertEquals("changed", exchange.getMessage().getBody(String.class));
+        assertEquals(false, exchange.getProperty(
+                CamelConstants.Properties.IS_CHAIN_CALL_TRIGGERED_SESSION, Boolean.class));
+    }
+
+    @Test
+    void shouldRestoreChainCallTriggeredSessionToTrueAfterDoneWhenPreviouslyTrue() {
+        Exchange exchange = new DefaultExchange(new DefaultCamelContext(), ExchangePattern.InOut);
+        exchange.setProperty(CamelConstants.Properties.IS_CHAIN_CALL_TRIGGERED_SESSION, true);
+
+        AsyncProcessor delegate = asyncProcessor((ex, cb) -> {
+            assertEquals(true, ex.getProperty(
+                    CamelConstants.Properties.IS_CHAIN_CALL_TRIGGERED_SESSION, Boolean.class));
+            cb.done(true);
+            return true;
+        });
+
+        ChainProcessor processor = new ChainProcessor(delegate, endpoint);
+
+        CapturingCallback callback = new CapturingCallback();
+        processor.process(exchange, callback);
+
+        assertEquals(true, callback.doneValue);
+        assertEquals(true, exchange.getProperty(
+                CamelConstants.Properties.IS_CHAIN_CALL_TRIGGERED_SESSION, Boolean.class));
+    }
+
+    @Test
+    void shouldCopyExceptionBackToOriginalExchange() {
+        Exchange exchange = new DefaultExchange(new DefaultCamelContext(), ExchangePattern.InOut);
+
+        IllegalStateException boom = new IllegalStateException("boom");
+        AsyncProcessor delegate = asyncProcessor((ex, cb) -> {
+            ex.setException(boom);
+            cb.done(true);
+            return true;
+        });
+
+        ChainProcessor processor = new ChainProcessor(delegate, endpoint);
+
+        CapturingCallback callback = new CapturingCallback();
+        processor.process(exchange, callback);
+
+        assertEquals(true, callback.doneValue);
+        assertSame(boom, exchange.getException());
+    }
+
+    @Test
+    void shouldSwitchAndRestoreThreadContextClassLoaderWhenApplicationContextClassLoaderProvided() {
+        ClassLoader originalCl = Thread.currentThread().getContextClassLoader();
+        ClassLoader appCl = new ClassLoader() {
+        };
+
+        CamelContext ctxWithAppCl = new DefaultCamelContext() {
+            @Override
+            public ClassLoader getApplicationContextClassLoader() {
+                return appCl;
+            }
+        };
+
+        component.setCamelContext(ctxWithAppCl);
+        endpoint = new ChainEndpoint("cip-chain:routeA", component);
+
+        Exchange exchange = new DefaultExchange(new DefaultCamelContext(), ExchangePattern.InOut);
+
+        AsyncProcessor delegate = asyncProcessor((ex, cb) -> {
+            assertSame(appCl, Thread.currentThread().getContextClassLoader());
+            cb.done(true);
+            return true;
+        });
+
+        ChainProcessor processor = new ChainProcessor(delegate, endpoint);
+
+        CapturingCallback callback = new CapturingCallback();
+        try {
+            processor.process(exchange, callback);
+            assertEquals(true, callback.doneValue);
+        } finally {
+            assertSame(originalCl, Thread.currentThread().getContextClassLoader());
+        }
+    }
+
+    @FunctionalInterface
+    private interface AsyncHandler {
+        boolean handle(Exchange exchange, AsyncCallback callback);
+    }
+
+    private static AsyncProcessor asyncProcessor(AsyncHandler handler) {
+        return new AsyncProcessor() {
+            @Override
+            public void process(Exchange exchange) {
+                throw new UnsupportedOperationException("not used");
+            }
+
+            @Override
+            public boolean process(Exchange exchange, AsyncCallback callback) {
+                return handler.handle(exchange, callback);
+            }
+
+            @Override
+            public CompletableFuture<Exchange> processAsync(Exchange exchange) {
+                return CompletableFuture.completedFuture(exchange);
+            }
+        };
+    }
+
+    private static final class CapturingCallback implements AsyncCallback {
+        Boolean doneValue;
+
+        @Override
+        public void done(boolean done) {
+            this.doneValue = done;
+        }
+    }
+}

--- a/src/test/java/org/qubership/integration/platform/engine/camel/components/directvm/ChainProducerTest.java
+++ b/src/test/java/org/qubership/integration/platform/engine/camel/components/directvm/ChainProducerTest.java
@@ -1,0 +1,229 @@
+package org.qubership.integration.platform.engine.camel.components.directvm;
+
+import org.apache.camel.AsyncCallback;
+import org.apache.camel.AsyncProcessor;
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.spi.HeaderFilterStrategy;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.qubership.integration.platform.engine.testutils.DisplayNameUtils;
+import org.qubership.integration.platform.engine.testutils.MockExchanges;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameUtils.ReplaceCamelCase.class)
+class ChainProducerTest {
+
+    @Mock
+    ChainEndpoint endpoint;
+    @Mock
+    ChainComponent component;
+    @Mock
+    ChainConsumer consumer;
+    @Mock
+    AsyncProcessor asyncProcessor;
+    @Mock
+    HeaderFilterStrategy headerFilterStrategy;
+
+    private ChainProducer producer;
+
+    @BeforeEach
+    void setUp() {
+        producer = new ChainProducer(endpoint);
+
+        when(endpoint.getComponent()).thenReturn(component);
+    }
+
+    @Test
+    void shouldSetExceptionAndCompleteCallbackWhenNoConsumerAndFailIfNoConsumersTrue() {
+        Exchange exchange = MockExchanges.defaultExchange();
+        AsyncCallback callback = mock(AsyncCallback.class);
+
+        when(component.getConsumer(endpoint)).thenReturn(null);
+        when(endpoint.isFailIfNoConsumers()).thenReturn(true);
+
+        boolean result = producer.process(exchange, callback);
+
+        assertTrue(result);
+        assertNotNull(exchange.getException());
+        assertInstanceOf(ChainConsumerNotAvailableException.class, exchange.getException());
+        verify(callback).done(true);
+    }
+
+    @Test
+    void shouldIgnoreMessageAndCompleteCallbackWhenNoConsumerAndFailIfNoConsumersFalse() {
+        Exchange exchange = MockExchanges.defaultExchange();
+        AsyncCallback callback = mock(AsyncCallback.class);
+
+        when(component.getConsumer(endpoint)).thenReturn(null);
+        when(endpoint.isFailIfNoConsumers()).thenReturn(false);
+
+        boolean result = producer.process(exchange, callback);
+
+        assertTrue(result);
+        assertNull(exchange.getException());
+        verify(callback).done(true);
+    }
+
+    @Test
+    void shouldProcessOnSameExchangeWhenPropagatePropertiesTrueAndNoHeaderFilter() {
+        Exchange exchange = MockExchanges.defaultExchange();
+        exchange.getProperties().put("p", "v");
+        exchange.getIn().setHeader("h", "v");
+
+        AsyncCallback callback = mock(AsyncCallback.class);
+
+        when(component.getConsumer(endpoint)).thenReturn(consumer);
+        when(consumer.getAsyncProcessor()).thenReturn(asyncProcessor);
+
+        when(endpoint.isPropagateProperties()).thenReturn(true);
+        when(endpoint.getHeaderFilterStrategy()).thenReturn(null);
+
+        when(asyncProcessor.process(any(Exchange.class), any(AsyncCallback.class))).thenAnswer(inv -> {
+            Exchange submitted = inv.getArgument(0);
+            AsyncCallback doneCb = inv.getArgument(1);
+
+            assertSame(exchange, submitted);
+
+            submitted.getMessage().setHeader("resp", "ok");
+            doneCb.done(false);
+            return false;
+        });
+
+        boolean result = producer.process(exchange, callback);
+
+        assertFalse(result);
+        verify(asyncProcessor).process(any(Exchange.class), any(AsyncCallback.class));
+        verify(callback).done(false);
+        assertEquals("v", exchange.getProperties().get("p"));
+    }
+
+    @Test
+    void shouldCopyExchangeAndNotPropagatePropertiesWhenPropagatePropertiesFalse() {
+        Exchange exchange = MockExchanges.defaultExchange();
+        exchange.getProperties().put("p", "v");
+        exchange.getIn().setHeader("h", "v");
+
+        AsyncCallback callback = mock(AsyncCallback.class);
+
+        when(component.getConsumer(endpoint)).thenReturn(consumer);
+        when(consumer.getAsyncProcessor()).thenReturn(asyncProcessor);
+
+        when(endpoint.isPropagateProperties()).thenReturn(false);
+        when(endpoint.getHeaderFilterStrategy()).thenReturn(null);
+
+        when(asyncProcessor.process(any(Exchange.class), any(AsyncCallback.class))).thenAnswer(inv -> {
+            Exchange submitted = inv.getArgument(0);
+            AsyncCallback doneCb = inv.getArgument(1);
+
+            assertNotSame(exchange, submitted);
+            assertTrue(submitted.getProperties().isEmpty(),
+                    "submitted properties must be cleared when propagateProperties=false");
+
+            submitted.getMessage().setHeader("resp", "ok");
+            submitted.setException(new IllegalStateException("boom"));
+
+            doneCb.done(true);
+            return true;
+        });
+
+        boolean result = producer.process(exchange, callback);
+
+        assertTrue(result);
+
+        assertNotNull(exchange.getException());
+        assertInstanceOf(IllegalStateException.class, exchange.getException());
+
+        assertEquals("ok", exchange.getOut().getHeader("resp"));
+
+        assertEquals("v", exchange.getProperties().get("p"));
+
+        verify(asyncProcessor).process(any(Exchange.class), any(AsyncCallback.class));
+        verify(callback).done(true);
+    }
+
+    @Test
+    void shouldFilterHeadersUsingHeaderFilterStrategy() {
+        Exchange exchange = MockExchanges.defaultExchange();
+        exchange.getIn().setHeader("keep", "1");
+        exchange.getIn().setHeader("removeCamel", "x");
+
+        AsyncCallback callback = mock(AsyncCallback.class);
+
+        when(component.getConsumer(endpoint)).thenReturn(consumer);
+        when(consumer.getAsyncProcessor()).thenReturn(asyncProcessor);
+
+        when(endpoint.isPropagateProperties()).thenReturn(true);
+        when(endpoint.getHeaderFilterStrategy()).thenReturn(headerFilterStrategy);
+
+        when(headerFilterStrategy.applyFilterToCamelHeaders(eq("removeCamel"), any(), any(Exchange.class))).thenReturn(true);
+        when(headerFilterStrategy.applyFilterToCamelHeaders(eq("keep"), any(), any(Exchange.class))).thenReturn(false);
+
+        when(headerFilterStrategy.applyFilterToExternalHeaders(eq("removeExternal"), any(), any(Exchange.class))).thenReturn(true);
+        when(headerFilterStrategy.applyFilterToExternalHeaders(eq("keepExternal"), any(), any(Exchange.class))).thenReturn(false);
+
+        when(asyncProcessor.process(any(Exchange.class), any(AsyncCallback.class))).thenAnswer(inv -> {
+            Exchange submitted = inv.getArgument(0);
+            AsyncCallback doneCb = inv.getArgument(1);
+
+            assertNotSame(exchange, submitted);
+
+            Map<String, Object> submittedHeaders = submitted.getIn().getHeaders();
+            assertTrue(submittedHeaders.containsKey("keep"));
+            assertFalse(submittedHeaders.containsKey("removeCamel"));
+
+            Message msg = submitted.getMessage();
+            msg.setHeader("removeExternal", "x");
+            msg.setHeader("keepExternal", "y");
+
+            doneCb.done(true);
+            return true;
+        });
+
+        boolean result = producer.process(exchange, callback);
+
+        assertTrue(result);
+
+        assertNull(exchange.getOut().getHeader("removeExternal"));
+        assertEquals("y", exchange.getOut().getHeader("keepExternal"));
+
+        assertNull(exchange.getOut().getHeader("removeCamel"));
+        assertEquals("1", exchange.getOut().getHeader("keep"));
+
+        verify(asyncProcessor).process(any(Exchange.class), any(AsyncCallback.class));
+        verify(callback).done(true);
+        verify(headerFilterStrategy, atLeastOnce()).applyFilterToCamelHeaders(anyString(), any(), any(Exchange.class));
+        verify(headerFilterStrategy, atLeastOnce()).applyFilterToExternalHeaders(anyString(), any(), any(Exchange.class));
+    }
+
+    @Test
+    void shouldSetExceptionAndCompleteCallbackWhenAsyncProcessorThrows() {
+        Exchange exchange = MockExchanges.defaultExchange();
+        AsyncCallback callback = mock(AsyncCallback.class);
+
+        when(component.getConsumer(endpoint)).thenReturn(consumer);
+        when(consumer.getAsyncProcessor()).thenReturn(asyncProcessor);
+
+        when(endpoint.isPropagateProperties()).thenReturn(true);
+        when(endpoint.getHeaderFilterStrategy()).thenReturn(null);
+
+        RuntimeException boom = new RuntimeException("boom");
+        when(asyncProcessor.process(any(Exchange.class), any(AsyncCallback.class))).thenThrow(boom);
+
+        boolean result = producer.process(exchange, callback);
+
+        assertTrue(result);
+        assertSame(boom, exchange.getException());
+        verify(asyncProcessor).process(any(Exchange.class), any(AsyncCallback.class));
+        verify(callback).done(true);
+    }
+}

--- a/src/test/java/org/qubership/integration/platform/engine/camel/components/graphql/GraphqlCustomComponentTest.java
+++ b/src/test/java/org/qubership/integration/platform/engine/camel/components/graphql/GraphqlCustomComponentTest.java
@@ -1,0 +1,60 @@
+package org.qubership.integration.platform.engine.camel.components.graphql;
+
+import org.apache.camel.Endpoint;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.Test;
+import org.qubership.integration.platform.engine.testutils.DisplayNameUtils;
+
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayNameGeneration(DisplayNameUtils.ReplaceCamelCase.class)
+class GraphqlCustomComponentTest {
+
+    private GraphqlCustomComponent component;
+
+    @BeforeEach
+    void setUp() {
+        component = new GraphqlCustomComponent();
+        component.setCamelContext(new DefaultCamelContext());
+    }
+
+    @Test
+    void shouldCreateGraphqlCustomEndpointAndSetHttpUriFromRemaining() throws Exception {
+        Endpoint ep = component.createEndpoint(
+                "graphql-custom:http://localhost/graphql",
+                "http://localhost/graphql",
+                new HashMap<>()
+        );
+
+        assertNotNull(ep);
+        assertInstanceOf(GraphqlCustomEndpoint.class, ep);
+
+        GraphqlCustomEndpoint endpoint = (GraphqlCustomEndpoint) ep;
+        assertEquals(new URI("http://localhost/graphql"), endpoint.getHttpUri());
+    }
+
+    @Test
+    void shouldApplyPropertiesToEndpointWhenParametersProvided() throws Exception {
+        Map<String, Object> params = new HashMap<>();
+        params.put("query", "query { test }");
+        params.put("proxyHost", "proxy.local:3128");
+
+        Endpoint ep = component.createEndpoint(
+                "graphql-custom:http://localhost/graphql",
+                "http://localhost/graphql",
+                params
+        );
+
+        GraphqlCustomEndpoint endpoint = (GraphqlCustomEndpoint) ep;
+
+        assertEquals("query { test }", endpoint.getQuery());
+        assertEquals("proxy.local:3128", endpoint.getProxyHost());
+        assertEquals(new URI("http://localhost/graphql"), endpoint.getHttpUri());
+    }
+}

--- a/src/test/java/org/qubership/integration/platform/engine/camel/components/graphql/GraphqlCustomEndpointTest.java
+++ b/src/test/java/org/qubership/integration/platform/engine/camel/components/graphql/GraphqlCustomEndpointTest.java
@@ -1,0 +1,198 @@
+package org.qubership.integration.platform.engine.camel.components.graphql;
+
+import org.apache.camel.Component;
+import org.apache.camel.Producer;
+import org.apache.camel.component.http.HttpClientConfigurer;
+import org.apache.hc.client5.http.auth.AuthScope;
+import org.apache.hc.client5.http.auth.CredentialsProvider;
+import org.apache.hc.client5.http.auth.UsernamePasswordCredentials;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.http.HttpHeaders;
+import org.apache.hc.core5.http.HttpHost;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.qubership.integration.platform.engine.testutils.DisplayNameUtils;
+
+import java.lang.reflect.Field;
+import java.util.Collection;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameUtils.ReplaceCamelCase.class)
+class GraphqlCustomEndpointTest {
+
+    @Mock
+    Component component;
+    @Mock
+    HttpClientConfigurer httpClientConfigurer;
+
+    private GraphqlCustomEndpoint endpoint;
+
+    @BeforeEach
+    void setUp() {
+        endpoint = new GraphqlCustomEndpoint("graphql-custom:http://localhost/graphql", component);
+    }
+
+    @Test
+    void shouldCreateGraphqlCustomProducerWhenCreateProducer() throws Exception {
+        Producer producer = endpoint.createProducer();
+
+        assertNotNull(producer);
+        assertInstanceOf(GraphqlCustomProducer.class, producer);
+    }
+
+    @Test
+    void shouldReturnExistingHttpClientWhenHttpClientAlreadySet() {
+        CloseableHttpClient existing = mock(CloseableHttpClient.class);
+        endpoint.setHttpClient(existing);
+
+        endpoint.setHttpClientConfigurer(httpClientConfigurer);
+
+        CloseableHttpClient out = endpoint.getHttpclient();
+
+        assertSame(existing, out);
+        verifyNoInteractions(httpClientConfigurer);
+    }
+
+    @Test
+    void shouldCreateAndCacheHttpClientAndApplyProxyAuthAndConfigurerWhenHttpClientNotSet() throws Exception {
+        endpoint.setHttpClientConfigurer(httpClientConfigurer);
+
+        endpoint.setProxyHost("proxy.local:3128");
+
+        endpoint.setAccessToken("tkn");
+        endpoint.setJwtAuthorizationType("Token");
+
+        endpoint.setUsername("user");
+        endpoint.setPassword("pass");
+
+        CloseableHttpClient c1 = endpoint.getHttpclient();
+        CloseableHttpClient c2 = endpoint.getHttpclient();
+
+        assertNotNull(c1);
+        assertSame(c1, c2);
+
+        ArgumentCaptor<HttpClientBuilder> builderCaptor = ArgumentCaptor.forClass(HttpClientBuilder.class);
+        verify(httpClientConfigurer, times(1)).configureHttpClient(builderCaptor.capture());
+
+        HttpClientBuilder builder = builderCaptor.getValue();
+
+        HttpHost proxy = readFirstFieldAssignableTo(builder, HttpHost.class);
+        assertNotNull(proxy);
+        assertEquals("proxy.local", proxy.getHostName());
+        assertEquals(3128, proxy.getPort());
+
+        Object defaultHeadersObj = readFieldByName(builder);
+        assertNotNull(defaultHeadersObj);
+        assertInstanceOf(Collection.class, defaultHeadersObj);
+
+        @SuppressWarnings("unchecked")
+        Collection<Header> defaultHeaders = (Collection<Header>) defaultHeadersObj;
+
+        Header auth = defaultHeaders.stream()
+                .filter(h -> HttpHeaders.AUTHORIZATION.equalsIgnoreCase(h.getName()))
+                .findFirst()
+                .orElse(null);
+
+        assertNotNull(auth);
+        assertEquals("Token tkn", auth.getValue());
+
+        CredentialsProvider credentialsProvider =
+                readFirstFieldAssignableTo(builder, CredentialsProvider.class);
+        assertNotNull(credentialsProvider);
+
+        var credentials = credentialsProvider.getCredentials(new AuthScope(null, -1), null);
+        assertNotNull(credentials);
+        assertInstanceOf(UsernamePasswordCredentials.class, credentials);
+
+        UsernamePasswordCredentials up = (UsernamePasswordCredentials) credentials;
+        assertEquals("user", up.getUserName());
+        assertArrayEquals("pass".toCharArray(), up.getPassword());
+        assertNotNull(credentials);
+        assertInstanceOf(UsernamePasswordCredentials.class, credentials);
+    }
+
+    @Test
+    void shouldUseBearerAuthorizationTypeWhenAccessTokenPresentAndJwtAuthorizationTypeNull() throws Exception {
+        endpoint.setHttpClientConfigurer(httpClientConfigurer);
+
+        endpoint.setAccessToken("tkn");
+        endpoint.setJwtAuthorizationType(null);
+
+        endpoint.getHttpclient();
+
+        ArgumentCaptor<HttpClientBuilder> builderCaptor = ArgumentCaptor.forClass(HttpClientBuilder.class);
+        verify(httpClientConfigurer).configureHttpClient(builderCaptor.capture());
+
+        HttpClientBuilder builder = builderCaptor.getValue();
+
+        Object defaultHeadersObj = readFieldByName(builder);
+        assertNotNull(defaultHeadersObj);
+        assertInstanceOf(Collection.class, defaultHeadersObj);
+
+        @SuppressWarnings("unchecked")
+        Collection<Header> defaultHeaders = (Collection<Header>) defaultHeadersObj;
+
+        Header auth = defaultHeaders.stream()
+                .filter(h -> HttpHeaders.AUTHORIZATION.equalsIgnoreCase(h.getName()))
+                .findFirst()
+                .orElse(null);
+
+        assertNotNull(auth);
+        assertEquals("Bearer tkn", auth.getValue());
+    }
+
+    private static Object readFieldByName(Object target) throws Exception {
+        Field f = findField(target.getClass());
+        assert f != null;
+        f.setAccessible(true);
+        return f.get(target);
+    }
+
+    private static Field findField(Class<?> type) {
+        Class<?> cur = type;
+        while (cur != null) {
+            for (Field f : cur.getDeclaredFields()) {
+                if (f.getName().equals("defaultHeaders")) {
+                    return f;
+                }
+            }
+            cur = cur.getSuperclass();
+        }
+        assert type != null;
+        fail("Field '" + "defaultHeaders" + "' not found on " + type.getName());
+        return null;
+    }
+
+    private static <T> T readFirstFieldAssignableTo(Object target, Class<T> fieldType) throws Exception {
+        Field f = findFirstFieldAssignableTo(target.getClass(), fieldType);
+        assert f != null;
+        f.setAccessible(true);
+        Object value = f.get(target);
+        return value == null ? null : fieldType.cast(value);
+    }
+
+    private static Field findFirstFieldAssignableTo(Class<?> type, Class<?> fieldType) {
+        Class<?> cur = type;
+        while (cur != null) {
+            for (Field f : cur.getDeclaredFields()) {
+                if (fieldType.isAssignableFrom(f.getType())) {
+                    return f;
+                }
+            }
+            cur = cur.getSuperclass();
+        }
+        assert type != null;
+        fail("No field assignable to " + fieldType.getName() + " found on " + type.getName());
+        return null;
+    }
+}

--- a/src/test/java/org/qubership/integration/platform/engine/camel/components/graphql/GraphqlCustomProducerTest.java
+++ b/src/test/java/org/qubership/integration/platform/engine/camel/components/graphql/GraphqlCustomProducerTest.java
@@ -1,0 +1,176 @@
+package org.qubership.integration.platform.engine.camel.components.graphql;
+
+import org.apache.camel.AsyncCallback;
+import org.apache.camel.Exchange;
+import org.apache.camel.component.graphql.GraphqlEndpoint;
+import org.apache.camel.http.base.HttpOperationFailedException;
+import org.apache.camel.util.json.JsonObject;
+import org.apache.hc.client5.http.classic.methods.HttpPost;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
+import org.apache.hc.core5.http.*;
+import org.apache.hc.core5.http.io.entity.EntityUtils;
+import org.apache.hc.core5.http.io.entity.StringEntity;
+import org.apache.hc.core5.http.message.BasicHeader;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.qubership.integration.platform.engine.model.constants.CamelConstants.Headers;
+import org.qubership.integration.platform.engine.testutils.DisplayNameUtils;
+import org.qubership.integration.platform.engine.testutils.MockExchanges;
+
+import java.net.URI;
+
+import static org.apache.camel.Exchange.HTTP_RESPONSE_CODE;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameUtils.ReplaceCamelCase.class)
+class GraphqlCustomProducerTest {
+    @Mock
+    GraphqlEndpoint endpoint;
+    @Mock
+    CloseableHttpClient httpClient;
+    @Mock
+    CloseableHttpResponse response;
+    @Mock
+    Exchange exchange;
+    @Mock
+    AsyncCallback callback;
+
+    @BeforeEach
+    public void setUp() {
+        endpoint = mock(GraphqlEndpoint.class);
+        httpClient = mock(CloseableHttpClient.class);
+        response = mock(CloseableHttpResponse.class);
+        exchange = MockExchanges.defaultExchange();
+        callback = mock(AsyncCallback.class);
+    }
+
+    @Test
+    void shouldExecuteHttpPostAndSetBodyAndHeadersWhenResponseSuccessful() throws Exception {
+        URI uri = URI.create("http://localhost/graphql");
+
+        when(endpoint.getHttpclient()).thenReturn(httpClient);
+        when(endpoint.getHttpUri()).thenReturn(uri);
+
+        when(endpoint.getQuery()).thenReturn("query { test }");
+
+        JsonObject vars = new JsonObject();
+        vars.put("a", "b");
+        when(endpoint.getVariables()).thenReturn(vars);
+
+        when(response.getCode()).thenReturn(200);
+        when(response.getEntity()).thenReturn(new StringEntity("{\"data\":1}", ContentType.APPLICATION_JSON));
+        when(response.getHeaders()).thenReturn(new Header[]{
+                new BasicHeader("X-Resp", "r1"),
+                new BasicHeader("X-Req", "override")
+        });
+
+        when(httpClient.execute(any(ClassicHttpRequest.class))).thenReturn(response);
+
+        exchange.getMessage().setHeader("X-Req", "v1");
+        exchange.getMessage().setHeader(Headers.GQL_QUERY_HEADER, "must-be-excluded");
+        exchange.getMessage().setHeader(Headers.GQL_VARIABLES_HEADER, "must-be-excluded");
+        exchange.getMessage().setHeader(HttpHeaders.CONTENT_LENGTH, "123");
+        exchange.getMessage().setHeader("X-NonString", 123);
+
+        GraphqlCustomProducer producer = new GraphqlCustomProducer(endpoint);
+        boolean result = producer.process(exchange, callback);
+
+        assertTrue(result);
+
+        assertEquals(200, exchange.getMessage().getHeader(HTTP_RESPONSE_CODE));
+        assertEquals("{\"data\":1}", exchange.getMessage().getBody(String.class));
+
+        assertEquals("r1", exchange.getMessage().getHeader("X-Resp"));
+        assertEquals("override", exchange.getMessage().getHeader("X-Req"));
+
+        ArgumentCaptor<ClassicHttpRequest> requestCaptor = ArgumentCaptor.forClass(ClassicHttpRequest.class);
+        verify(httpClient).execute(requestCaptor.capture());
+
+        assertInstanceOf(HttpPost.class, requestCaptor.getValue());
+        HttpPost post = (HttpPost) requestCaptor.getValue();
+
+        assertEquals("application/json", post.getFirstHeader(HttpHeaders.ACCEPT).getValue());
+        assertEquals("gzip", post.getFirstHeader(HttpHeaders.ACCEPT_ENCODING).getValue());
+
+        assertEquals("v1", post.getFirstHeader("X-Req").getValue());
+        assertNull(post.getFirstHeader(Headers.GQL_QUERY_HEADER));
+        assertNull(post.getFirstHeader(Headers.GQL_VARIABLES_HEADER));
+        assertNull(post.getFirstHeader(HttpHeaders.CONTENT_LENGTH));
+        assertNull(post.getFirstHeader("X-NonString"));
+
+        HttpEntity reqEntity = post.getEntity();
+        String reqBody = EntityUtils.toString(reqEntity);
+        assertTrue(reqBody.contains("query { test }"));
+        assertTrue(reqBody.contains("a"));
+
+        verify(callback).done(true);
+        assertNull(exchange.getException());
+    }
+
+    @Test
+    void shouldSetHttpOperationFailedExceptionWhenStatusIsError() throws Exception {
+        URI uri = URI.create("http://localhost/graphql");
+
+        when(endpoint.getHttpclient()).thenReturn(httpClient);
+        when(endpoint.getHttpUri()).thenReturn(uri);
+        when(endpoint.getQuery()).thenReturn("query { err }");
+
+        when(response.getCode()).thenReturn(500);
+        when(response.getReasonPhrase()).thenReturn("Internal Server Error");
+        when(response.getEntity()).thenReturn(new StringEntity("boom", ContentType.TEXT_PLAIN));
+        when(response.getHeaders()).thenReturn(new Header[]{new BasicHeader("X-Err", "1")});
+
+        when(httpClient.execute(any(ClassicHttpRequest.class))).thenReturn(response);
+
+        GraphqlCustomProducer producer = new GraphqlCustomProducer(endpoint);
+        boolean result = producer.process(exchange, callback);
+
+        assertTrue(result);
+
+        assertEquals(500, exchange.getMessage().getHeader(HTTP_RESPONSE_CODE));
+        assertNotNull(exchange.getException());
+        assertInstanceOf(HttpOperationFailedException.class, exchange.getException());
+
+        verify(callback).done(true);
+    }
+
+    @Test
+    void shouldReadQueryFromHeaderWhenEndpointQueryNullAndQueryHeaderProvided() throws Exception {
+        URI uri = URI.create("http://localhost/graphql");
+
+        when(endpoint.getHttpclient()).thenReturn(httpClient);
+        when(endpoint.getHttpUri()).thenReturn(uri);
+
+        when(endpoint.getQuery()).thenReturn(null);
+        when(endpoint.getQueryHeader()).thenReturn("X-Query");
+
+        when(response.getCode()).thenReturn(200);
+        when(response.getEntity()).thenReturn(new StringEntity("ok", ContentType.TEXT_PLAIN));
+        when(response.getHeaders()).thenReturn(new Header[0]);
+
+        when(httpClient.execute(any(ClassicHttpRequest.class))).thenReturn(response);
+
+        exchange.getIn().setHeader("X-Query", "query { fromHeader }");
+
+        GraphqlCustomProducer producer = new GraphqlCustomProducer(endpoint);
+        producer.process(exchange, callback);
+
+        ArgumentCaptor<ClassicHttpRequest> requestCaptor = ArgumentCaptor.forClass(ClassicHttpRequest.class);
+        verify(httpClient).execute(requestCaptor.capture());
+
+        HttpPost post = (HttpPost) requestCaptor.getValue();
+        String reqBody = EntityUtils.toString(post.getEntity());
+        assertTrue(reqBody.contains("fromHeader"));
+
+        verify(callback).done(true);
+    }
+}

--- a/src/test/java/org/qubership/integration/platform/engine/camel/metadata/MetadataServiceTest.java
+++ b/src/test/java/org/qubership/integration/platform/engine/camel/metadata/MetadataServiceTest.java
@@ -1,0 +1,118 @@
+package org.qubership.integration.platform.engine.camel.metadata;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.Exchange;
+import org.apache.camel.Route;
+import org.apache.camel.model.RouteDefinition;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.qubership.integration.platform.engine.model.constants.CamelConstants;
+import org.qubership.integration.platform.engine.testutils.DisplayNameUtils;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameUtils.ReplaceCamelCase.class)
+class MetadataServiceTest {
+
+    @Mock
+    MetadataConverter converter;
+
+    @InjectMocks
+    MetadataService service;
+
+    @Test
+    void shouldReturnMetadataWhenRouteHasRouteMetadataKey() {
+        Route route = mock(Route.class);
+        Metadata metadata = mock(Metadata.class);
+
+        Map<String, Object> props = new HashMap<>();
+        props.put(CamelConstants.ROUTE_METADATA_KEY, metadata);
+        when(route.getProperties()).thenReturn(props);
+
+        Optional<Metadata> result = service.getMetadata(route);
+
+        assertTrue(result.isPresent());
+        assertSame(metadata, result.get());
+    }
+
+    @Test
+    void shouldReturnEmptyWhenRouteDoesNotHaveRouteMetadataKey() {
+        Route route = mock(Route.class);
+
+        Map<String, Object> props = new HashMap<>();
+        when(route.getProperties()).thenReturn(props);
+
+        Optional<Metadata> result = service.getMetadata(route);
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void shouldReturnMetadataWhenExchangeResolvesRouteFromContext() {
+        Exchange exchange = mock(Exchange.class);
+        CamelContext camelContext = mock(CamelContext.class);
+        Route route = mock(Route.class);
+        Metadata metadata = mock(Metadata.class);
+
+        when(exchange.getContext()).thenReturn(camelContext);
+        when(exchange.getFromRouteId()).thenReturn("route-1");
+        when(camelContext.getRoute("route-1")).thenReturn(route);
+
+        Map<String, Object> props = new HashMap<>();
+        props.put(CamelConstants.ROUTE_METADATA_KEY, metadata);
+        when(route.getProperties()).thenReturn(props);
+
+        Optional<Metadata> result = service.getMetadata(exchange);
+
+        assertTrue(result.isPresent());
+        assertSame(metadata, result.get());
+        verify(camelContext).getRoute("route-1");
+    }
+
+    @Test
+    void shouldReturnEmptyWhenCamelContextHasNoRouteForRouteId() {
+        CamelContext camelContext = mock(CamelContext.class);
+        when(camelContext.getRoute("missing-route")).thenReturn(null);
+
+        Optional<Metadata> result = service.getMetadata(camelContext, "missing-route");
+
+        assertTrue(result.isEmpty());
+        verify(camelContext).getRoute("missing-route");
+    }
+
+    @Test
+    void shouldReturnEmptyWhenRouteExistsButHasNoMetadata() {
+        CamelContext camelContext = mock(CamelContext.class);
+        Route route = mock(Route.class);
+
+        when(camelContext.getRoute("route-1")).thenReturn(route);
+        when(route.getProperties()).thenReturn(new HashMap<>());
+
+        Optional<Metadata> result = service.getMetadata(camelContext, "route-1");
+
+        assertTrue(result.isEmpty());
+    }
+
+    @Test
+    void shouldSetRoutePropertyWithConvertedMetadataWhenSetMetadata() {
+        RouteDefinition routeDefinition = mock(RouteDefinition.class);
+        Metadata metadata = mock(Metadata.class);
+
+        when(converter.toString(metadata)).thenReturn("meta-as-string");
+
+        service.setMetadata(routeDefinition, metadata);
+
+        verify(routeDefinition).routeProperty(CamelConstants.ROUTE_METADATA_KEY, "meta-as-string");
+        verify(converter).toString(metadata);
+    }
+}

--- a/src/test/java/org/qubership/integration/platform/engine/camel/scheduler/SchedulerProxyTest.java
+++ b/src/test/java/org/qubership/integration/platform/engine/camel/scheduler/SchedulerProxyTest.java
@@ -1,0 +1,181 @@
+package org.qubership.integration.platform.engine.camel.scheduler;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.quartz.JobDetail;
+import org.quartz.Scheduler;
+import org.quartz.Trigger;
+import org.qubership.integration.platform.engine.testutils.DisplayNameUtils;
+
+import java.util.Date;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameUtils.ReplaceCamelCase.class)
+class SchedulerProxyTest {
+
+    @Mock
+    Scheduler scheduler;
+
+    private SchedulerProxy proxy;
+
+    @BeforeEach
+    void setUp() {
+        proxy = new SchedulerProxy(scheduler);
+    }
+
+    @Test
+    void shouldDelayScheduleJobAndNotDelegateWhenScheduleJobCalled() throws Exception {
+        JobDetail job = job("job-1");
+        Trigger trigger = trigger("tr-1");
+
+        Date result = proxy.scheduleJob(job, trigger);
+
+        assertNotNull(result);
+        verifyNoInteractions(scheduler);
+    }
+
+    @Test
+    void shouldCommitScheduledJobsByDelegatingAndClearing() throws Exception {
+        JobDetail job1 = job("job-1");
+        Trigger tr1 = trigger("tr-1");
+        JobDetail job2 = job("job-2");
+        Trigger tr2 = trigger("tr-2");
+
+        proxy.scheduleJob(job1, tr1);
+        proxy.scheduleJob(job2, tr2);
+
+        proxy.commitScheduledJobs();
+
+        ArgumentCaptor<JobDetail> jobCaptor = ArgumentCaptor.forClass(JobDetail.class);
+        @SuppressWarnings({"rawtypes", "unchecked"})
+        ArgumentCaptor<Set> triggersCaptor = (ArgumentCaptor) ArgumentCaptor.forClass(Set.class);
+
+        verify(scheduler, times(2)).scheduleJob(jobCaptor.capture(), triggersCaptor.capture(), eq(true));
+
+        List<JobDetail> jobs = jobCaptor.getAllValues();
+        List<Set> triggerSets = triggersCaptor.getAllValues();
+
+        assertEquals(List.of(job1, job2), jobs);
+        assertEquals(Set.of(tr1), triggerSets.get(0));
+        assertEquals(Set.of(tr2), triggerSets.get(1));
+
+        proxy.commitScheduledJobs();
+        verifyNoMoreInteractions(scheduler);
+    }
+
+    @Test
+    void shouldDelegateStartWhenNotSuspended() throws Exception {
+        proxy.start();
+
+        verify(scheduler).start();
+    }
+
+    @Test
+    void shouldDelegateStartDelayedWhenNotSuspended() throws Exception {
+        proxy.startDelayed(5);
+
+        verify(scheduler).startDelayed(5);
+    }
+
+    @Test
+    void shouldNotDelegateStartWhenSuspended() throws Exception {
+        when(scheduler.isInStandbyMode()).thenReturn(false);
+
+        proxy.suspendScheduler();
+        proxy.start();
+
+        verify(scheduler, never()).start();
+        verify(scheduler).standby();
+    }
+
+    @Test
+    void shouldNotDelegateStartDelayedWhenSuspended() throws Exception {
+        when(scheduler.isInStandbyMode()).thenReturn(false);
+
+        proxy.suspendScheduler();
+        proxy.startDelayed(5);
+
+        verify(scheduler, never()).startDelayed(anyInt());
+        verify(scheduler).standby();
+    }
+
+    @Test
+    void shouldDoNothingWhenShutdownCalled() {
+        proxy.shutdown(true);
+
+        verifyNoInteractions(scheduler);
+    }
+
+    @Test
+    void shouldPutSchedulerIntoStandbyWhenSuspendingAndNotAlreadyInStandbyMode() throws Exception {
+        when(scheduler.isInStandbyMode()).thenReturn(false);
+
+        proxy.suspendScheduler();
+        proxy.suspendScheduler();
+
+        verify(scheduler, times(1)).isInStandbyMode();
+        verify(scheduler, times(1)).standby();
+        verify(scheduler, never()).start();
+        verify(scheduler, never()).resumeAll();
+    }
+
+    @Test
+    void shouldNotCallStandbyWhenAlreadyInStandbyMode() throws Exception {
+        when(scheduler.isInStandbyMode()).thenReturn(true);
+
+        proxy.suspendScheduler();
+
+        verify(scheduler).isInStandbyMode();
+        verify(scheduler, never()).standby();
+    }
+
+    @Test
+    void shouldStartAndResumeAllWhenResumingAfterSuspend() throws Exception {
+        when(scheduler.isInStandbyMode()).thenReturn(false);
+
+        proxy.suspendScheduler();
+        proxy.resumeScheduler();
+
+        InOrder inOrder = inOrder(scheduler);
+        inOrder.verify(scheduler).isInStandbyMode();
+        inOrder.verify(scheduler).standby();
+        inOrder.verify(scheduler).start();
+        inOrder.verify(scheduler).resumeAll();
+    }
+
+    @Test
+    void shouldDoNothingWhenResumingAndNotSuspended() throws Exception {
+        proxy.resumeScheduler();
+
+        verifyNoInteractions(scheduler);
+    }
+
+    @Test
+    void shouldClearDelayedJobsWhenClearDelayedJobsCalled() throws Exception {
+        proxy.scheduleJob(job("job-1"), trigger("tr-1"));
+
+        proxy.clearDelayedJobs();
+        proxy.commitScheduledJobs();
+
+        verifyNoInteractions(scheduler);
+    }
+
+    private JobDetail job(String name) {
+        return mock(JobDetail.class, name);
+    }
+
+    private Trigger trigger(String name) {
+        return mock(Trigger.class, name);
+    }
+}

--- a/src/test/java/org/qubership/integration/platform/engine/service/CheckpointSessionServiceTest.java
+++ b/src/test/java/org/qubership/integration/platform/engine/service/CheckpointSessionServiceTest.java
@@ -21,13 +21,19 @@ import io.quarkus.panache.common.Page;
 import io.quarkus.panache.common.Sort;
 import io.smallrye.mutiny.Uni;
 import io.vertx.mutiny.core.buffer.Buffer;
+import jakarta.inject.Inject;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.ws.rs.core.MediaType;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.http.HttpHeaders;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.qubership.integration.platform.engine.model.constants.CamelConstants.Headers;
 import org.qubership.integration.platform.engine.persistence.shared.entity.Checkpoint;
 import org.qubership.integration.platform.engine.persistence.shared.entity.SessionInfo;
@@ -41,29 +47,32 @@ import java.util.Optional;
 import java.util.function.Supplier;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
+@ExtendWith(MockitoExtension.class)
 @DisplayNameGeneration(DisplayNameUtils.ReplaceCamelCase.class)
 class CheckpointSessionServiceTest {
 
-    private CheckpointSessionService service(
-            SessionInfoRepository sessionInfoRepository,
-            CheckpointRepository checkpointRepository,
-            CheckpointRestService checkpointRestService,
-            ObjectMapper mapper
-    ) {
-        return new CheckpointSessionService(sessionInfoRepository, checkpointRepository, checkpointRestService, mapper);
+    @Mock
+    SessionInfoRepository sessionRepo;
+    @Mock
+    CheckpointRepository checkpointRepo;
+    @RestClient
+    @Inject
+    @Mock
+    CheckpointRestService rest;
+    @Mock
+    ObjectMapper mapper;
+
+    private CheckpointSessionService svc;
+
+    @BeforeEach
+    void setUp() {
+        svc = new CheckpointSessionService(sessionRepo, checkpointRepo, rest, mapper);
     }
 
     @Test
     void shouldThrowEntityNotFoundWhenRetryFromLastCheckpointAndNoCheckpoint() {
-        SessionInfoRepository sessionRepo = mock(SessionInfoRepository.class);
-        CheckpointRepository checkpointRepo = mock(CheckpointRepository.class);
-        CheckpointRestService rest = mock(CheckpointRestService.class);
-
-        CheckpointSessionService svc = service(sessionRepo, checkpointRepo, rest, mock(ObjectMapper.class));
-
         when(checkpointRepo.findAllBySessionChainIdAndSessionId(anyString(), anyString(), any(Page.class), any(Sort.class)))
                 .thenReturn(List.of());
 
@@ -76,22 +85,14 @@ class CheckpointSessionServiceTest {
 
     @Test
     void shouldCallRetryCheckpointWhenRetryFromLastCheckpointAndCheckpointExists() {
-        SessionInfoRepository sessionRepo = mock(SessionInfoRepository.class);
-        CheckpointRepository checkpointRepo = mock(CheckpointRepository.class);
-        CheckpointRestService rest = mock(CheckpointRestService.class);
+        Uni<Buffer> uni = mockUni();
+        when(rest.retryCheckpoint(
+                anyString(), anyString(), anyString(),
+                org.mockito.ArgumentMatchers.anyMap(),
+                org.mockito.ArgumentMatchers.any()
+        )).thenReturn(uni);
 
-        Uni<Buffer> uni = mock(Uni.class, RETURNS_DEEP_STUBS);
-        when(rest.retryCheckpoint(anyString(), anyString(), anyString(), anyMap(), any())).thenReturn(uni);
-
-        CheckpointSessionService svc = service(sessionRepo, checkpointRepo, rest, mock(ObjectMapper.class));
-
-        SessionInfo session = mock(SessionInfo.class);
-        when(session.getChainId()).thenReturn("chain");
-        when(session.getId()).thenReturn("session");
-
-        Checkpoint checkpoint = mock(Checkpoint.class);
-        when(checkpoint.getSession()).thenReturn(session);
-        when(checkpoint.getCheckpointElementId()).thenReturn("el-1");
+        Checkpoint checkpoint = checkpoint();
 
         when(checkpointRepo.findAllBySessionChainIdAndSessionId(eq("chain"), eq("session"), any(Page.class), any(Sort.class)))
                 .thenReturn(List.of(checkpoint));
@@ -100,8 +101,10 @@ class CheckpointSessionServiceTest {
 
         svc.retryFromLastCheckpoint("chain", "session", "{\"k\":\"v\"}", auth, true);
 
-        ArgumentCaptor<Map<String, String>> headersCaptor = ArgumentCaptor.forClass(Map.class);
-        ArgumentCaptor<Optional<String>> bodyCaptor = ArgumentCaptor.forClass(Optional.class);
+        @SuppressWarnings({"rawtypes", "unchecked"})
+        ArgumentCaptor<Map<String, String>> headersCaptor = (ArgumentCaptor) ArgumentCaptor.forClass(Map.class);
+        @SuppressWarnings({"rawtypes", "unchecked"})
+        ArgumentCaptor<Optional<String>> bodyCaptor = (ArgumentCaptor) ArgumentCaptor.forClass(Optional.class);
 
         verify(rest).retryCheckpoint(eq("chain"), eq("session"), eq("el-1"), headersCaptor.capture(), bodyCaptor.capture());
 
@@ -117,41 +120,29 @@ class CheckpointSessionServiceTest {
 
     @Test
     void shouldSendEmptyOptionalBodyWhenBodyBlank() {
-        SessionInfoRepository sessionRepo = mock(SessionInfoRepository.class);
-        CheckpointRepository checkpointRepo = mock(CheckpointRepository.class);
-        CheckpointRestService rest = mock(CheckpointRestService.class);
-
-        @SuppressWarnings("unchecked")
-        Uni<Buffer> uni = mock(Uni.class, RETURNS_DEEP_STUBS);
-
+        Uni<Buffer> uni = mockUni();
         when(rest.retryCheckpoint(
                 anyString(), anyString(), anyString(),
                 org.mockito.ArgumentMatchers.anyMap(),
                 org.mockito.ArgumentMatchers.any()
         )).thenReturn(uni);
 
-        CheckpointSessionService svc = service(sessionRepo, checkpointRepo, rest, mock(ObjectMapper.class));
-
-        SessionInfo session = mock(SessionInfo.class);
-        when(session.getChainId()).thenReturn("chain");
-        when(session.getId()).thenReturn("session");
-
-        Checkpoint checkpoint = mock(Checkpoint.class);
-        when(checkpoint.getSession()).thenReturn(session);
-        when(checkpoint.getCheckpointElementId()).thenReturn("el-1");
+        Checkpoint checkpoint = checkpoint();
 
         when(checkpointRepo.findAllBySessionChainIdAndSessionId(eq("chain"), eq("session"), any(Page.class), any(Sort.class)))
                 .thenReturn(List.of(checkpoint));
 
         svc.retryFromLastCheckpoint("chain", "session", "", () -> null, false);
 
-        ArgumentCaptor<Map<String, String>> headersCaptor = ArgumentCaptor.forClass(Map.class);
-        ArgumentCaptor<Optional<String>> bodyCaptor = ArgumentCaptor.forClass(Optional.class);
+        @SuppressWarnings({"rawtypes", "unchecked"})
+        ArgumentCaptor<Map<String, String>> headersCaptor = (ArgumentCaptor) ArgumentCaptor.forClass(Map.class);
+        @SuppressWarnings({"rawtypes", "unchecked"})
+        ArgumentCaptor<Optional<String>> bodyCaptor = (ArgumentCaptor) ArgumentCaptor.forClass(Optional.class);
 
         verify(rest).retryCheckpoint(eq("chain"), eq("session"), eq("el-1"), headersCaptor.capture(), bodyCaptor.capture());
 
         Map<String, String> hdrs = headersCaptor.getValue();
-        assertEquals("false", hdrs.get(org.qubership.integration.platform.engine.model.constants.CamelConstants.Headers.TRACE_ME));
+        assertEquals("false", hdrs.get(Headers.TRACE_ME));
         assertEquals(MediaType.APPLICATION_JSON, hdrs.get(HttpHeaders.CONTENT_TYPE));
         assertEquals(Optional.empty(), bodyCaptor.getValue());
 
@@ -160,12 +151,6 @@ class CheckpointSessionServiceTest {
 
     @Test
     void shouldThrowEntityNotFoundWhenRetryFromCheckpointAndCheckpointMissing() {
-        SessionInfoRepository sessionRepo = mock(SessionInfoRepository.class);
-        CheckpointRepository checkpointRepo = mock(CheckpointRepository.class);
-        CheckpointRestService rest = mock(CheckpointRestService.class);
-
-        CheckpointSessionService svc = service(sessionRepo, checkpointRepo, rest, mock(ObjectMapper.class));
-
         when(checkpointRepo.findFirstBySessionIdAndSessionChainIdAndCheckpointElementId(anyString(), anyString(), anyString()))
                 .thenReturn(null);
 
@@ -178,30 +163,24 @@ class CheckpointSessionServiceTest {
 
     @Test
     void shouldCallRetryCheckpointWhenRetryFromCheckpointAndCheckpointExists() {
-        SessionInfoRepository sessionRepo = mock(SessionInfoRepository.class);
-        CheckpointRepository checkpointRepo = mock(CheckpointRepository.class);
-        CheckpointRestService rest = mock(CheckpointRestService.class);
+        Uni<Buffer> uni = mockUni();
+        when(rest.retryCheckpoint(
+                anyString(), anyString(), anyString(),
+                org.mockito.ArgumentMatchers.anyMap(),
+                org.mockito.ArgumentMatchers.any()
+        )).thenReturn(uni);
 
-        Uni<Buffer> uni = mock(Uni.class, RETURNS_DEEP_STUBS);
-        when(rest.retryCheckpoint(anyString(), anyString(), anyString(), anyMap(), any())).thenReturn(uni);
-
-        CheckpointSessionService svc = service(sessionRepo, checkpointRepo, rest, mock(ObjectMapper.class));
-
-        SessionInfo session = mock(SessionInfo.class);
-        when(session.getChainId()).thenReturn("chain");
-        when(session.getId()).thenReturn("session");
-
-        Checkpoint checkpoint = mock(Checkpoint.class);
-        when(checkpoint.getSession()).thenReturn(session);
-        when(checkpoint.getCheckpointElementId()).thenReturn("el-1");
+        Checkpoint checkpoint = checkpoint();
 
         when(checkpointRepo.findFirstBySessionIdAndSessionChainIdAndCheckpointElementId("session", "chain", "el-1"))
                 .thenReturn(checkpoint);
 
         svc.retryFromCheckpoint("chain", "session", "el-1", "{\"a\":1}", () -> Pair.of("X", "Y"), true);
 
-        ArgumentCaptor<Map<String, String>> headersCaptor = ArgumentCaptor.forClass(Map.class);
-        ArgumentCaptor<Optional<String>> bodyCaptor = ArgumentCaptor.forClass(Optional.class);
+        @SuppressWarnings({"rawtypes", "unchecked"})
+        ArgumentCaptor<Map<String, String>> headersCaptor = (ArgumentCaptor) ArgumentCaptor.forClass(Map.class);
+        @SuppressWarnings({"rawtypes", "unchecked"})
+        ArgumentCaptor<Optional<String>> bodyCaptor = (ArgumentCaptor) ArgumentCaptor.forClass(Optional.class);
 
         verify(rest).retryCheckpoint(eq("chain"), eq("session"), eq("el-1"), headersCaptor.capture(), bodyCaptor.capture());
 
@@ -216,11 +195,6 @@ class CheckpointSessionServiceTest {
 
     @Test
     void shouldReturnNullWhenFindLastCheckpointAndRepositoryReturnsNullOrEmpty() {
-        SessionInfoRepository sessionRepo = mock(SessionInfoRepository.class);
-        CheckpointRepository checkpointRepo = mock(CheckpointRepository.class);
-
-        CheckpointSessionService svc = service(sessionRepo, checkpointRepo, mock(CheckpointRestService.class), mock(ObjectMapper.class));
-
         when(checkpointRepo.findAllBySessionChainIdAndSessionId(anyString(), anyString(), any(Page.class), any(Sort.class)))
                 .thenReturn(null);
 
@@ -234,11 +208,6 @@ class CheckpointSessionServiceTest {
 
     @Test
     void shouldReturnFirstWhenFindLastCheckpointAndRepositoryReturnsList() {
-        SessionInfoRepository sessionRepo = mock(SessionInfoRepository.class);
-        CheckpointRepository checkpointRepo = mock(CheckpointRepository.class);
-
-        CheckpointSessionService svc = service(sessionRepo, checkpointRepo, mock(CheckpointRestService.class), mock(ObjectMapper.class));
-
         Checkpoint c1 = mock(Checkpoint.class);
         Checkpoint c2 = mock(Checkpoint.class);
 
@@ -250,11 +219,6 @@ class CheckpointSessionServiceTest {
 
     @Test
     void shouldDelegateFindAllFailedChainSessionsInfo() {
-        SessionInfoRepository sessionRepo = mock(SessionInfoRepository.class);
-        CheckpointRepository checkpointRepo = mock(CheckpointRepository.class);
-
-        CheckpointSessionService svc = service(sessionRepo, checkpointRepo, mock(CheckpointRestService.class), mock(ObjectMapper.class));
-
         List<SessionInfo> list = List.of(mock(SessionInfo.class));
         when(sessionRepo.findAllByChainIdAndExecutionStatus("c", ExecutionStatus.COMPLETED_WITH_ERRORS)).thenReturn(list);
 
@@ -263,12 +227,8 @@ class CheckpointSessionServiceTest {
 
     @Test
     void shouldPersistAndReturnSameSessionWhenSaveSession() {
-        SessionInfoRepository sessionRepo = mock(SessionInfoRepository.class);
-        CheckpointRepository checkpointRepo = mock(CheckpointRepository.class);
-
-        CheckpointSessionService svc = service(sessionRepo, checkpointRepo, mock(CheckpointRestService.class), mock(ObjectMapper.class));
-
         SessionInfo session = mock(SessionInfo.class);
+
         SessionInfo out = svc.saveSession(session);
 
         assertSame(session, out);
@@ -277,11 +237,6 @@ class CheckpointSessionServiceTest {
 
     @Test
     void shouldThrowEntityNotFoundWhenSaveAndAssignCheckpointAndSessionMissing() {
-        SessionInfoRepository sessionRepo = mock(SessionInfoRepository.class);
-        CheckpointRepository checkpointRepo = mock(CheckpointRepository.class);
-
-        CheckpointSessionService svc = service(sessionRepo, checkpointRepo, mock(CheckpointRestService.class), mock(ObjectMapper.class));
-
         when(sessionRepo.findByIdOptional("s")).thenReturn(Optional.empty());
 
         Checkpoint checkpoint = mock(Checkpoint.class);
@@ -291,11 +246,6 @@ class CheckpointSessionServiceTest {
 
     @Test
     void shouldAssignCheckpointToSessionWhenSaveAndAssignCheckpointAndSessionExists() {
-        SessionInfoRepository sessionRepo = mock(SessionInfoRepository.class);
-        CheckpointRepository checkpointRepo = mock(CheckpointRepository.class);
-
-        CheckpointSessionService svc = service(sessionRepo, checkpointRepo, mock(CheckpointRestService.class), mock(ObjectMapper.class));
-
         SessionInfo session = mock(SessionInfo.class);
         when(sessionRepo.findByIdOptional("s")).thenReturn(Optional.of(session));
 
@@ -314,11 +264,6 @@ class CheckpointSessionServiceTest {
 
     @Test
     void shouldUpdateParentWhenBothSessionsExist() {
-        SessionInfoRepository sessionRepo = mock(SessionInfoRepository.class);
-        CheckpointRepository checkpointRepo = mock(CheckpointRepository.class);
-
-        CheckpointSessionService svc = service(sessionRepo, checkpointRepo, mock(CheckpointRestService.class), mock(ObjectMapper.class));
-
         SessionInfo session = mock(SessionInfo.class);
         SessionInfo parent = mock(SessionInfo.class);
 
@@ -332,11 +277,6 @@ class CheckpointSessionServiceTest {
 
     @Test
     void shouldThrowEntityNotFoundWhenUpdateParentAndAnySessionMissing() {
-        SessionInfoRepository sessionRepo = mock(SessionInfoRepository.class);
-        CheckpointRepository checkpointRepo = mock(CheckpointRepository.class);
-
-        CheckpointSessionService svc = service(sessionRepo, checkpointRepo, mock(CheckpointRestService.class), mock(ObjectMapper.class));
-
         when(sessionRepo.findByIdOptional("s")).thenReturn(Optional.empty());
 
         assertThrows(EntityNotFoundException.class, () -> svc.updateSessionParent("s", "p"));
@@ -344,11 +284,6 @@ class CheckpointSessionServiceTest {
 
     @Test
     void shouldDeleteRootSessionByIdWhenRemoveAllRelatedCheckpointsAndIsRoot() {
-        SessionInfoRepository sessionRepo = mock(SessionInfoRepository.class);
-        CheckpointRepository checkpointRepo = mock(CheckpointRepository.class);
-
-        CheckpointSessionService svc = service(sessionRepo, checkpointRepo, mock(CheckpointRestService.class), mock(ObjectMapper.class));
-
         svc.removeAllRelatedCheckpoints("s", true);
 
         verify(sessionRepo).deleteById("s");
@@ -357,11 +292,6 @@ class CheckpointSessionServiceTest {
 
     @Test
     void shouldDeleteRelatedWhenRemoveAllRelatedCheckpointsAndNotRoot() {
-        SessionInfoRepository sessionRepo = mock(SessionInfoRepository.class);
-        CheckpointRepository checkpointRepo = mock(CheckpointRepository.class);
-
-        CheckpointSessionService svc = service(sessionRepo, checkpointRepo, mock(CheckpointRestService.class), mock(ObjectMapper.class));
-
         svc.removeAllRelatedCheckpoints("s", false);
 
         verify(sessionRepo).deleteAllRelatedSessionsAndCheckpoints("s");
@@ -370,13 +300,24 @@ class CheckpointSessionServiceTest {
 
     @Test
     void shouldDelegateDeleteOldRecordsByInterval() {
-        SessionInfoRepository sessionRepo = mock(SessionInfoRepository.class);
-        CheckpointRepository checkpointRepo = mock(CheckpointRepository.class);
-
-        CheckpointSessionService svc = service(sessionRepo, checkpointRepo, mock(CheckpointRestService.class), mock(ObjectMapper.class));
-
         svc.deleteOldRecordsByInterval("P30D");
 
         verify(sessionRepo).deleteOldRecordsByInterval("P30D");
+    }
+
+    private Uni mockUni() {
+        return mock(Uni.class, RETURNS_DEEP_STUBS);
+    }
+
+    private Checkpoint checkpoint() {
+        SessionInfo session = mock(SessionInfo.class);
+        when(session.getChainId()).thenReturn("chain");
+        when(session.getId()).thenReturn("session");
+
+        Checkpoint checkpoint = mock(Checkpoint.class);
+        when(checkpoint.getSession()).thenReturn(session);
+        when(checkpoint.getCheckpointElementId()).thenReturn("el-1");
+
+        return checkpoint;
     }
 }

--- a/src/test/java/org/qubership/integration/platform/engine/service/QuartzSchedulerServiceTest.java
+++ b/src/test/java/org/qubership/integration/platform/engine/service/QuartzSchedulerServiceTest.java
@@ -1,0 +1,245 @@
+package org.qubership.integration.platform.engine.service;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.Consumer;
+import org.apache.camel.Endpoint;
+import org.apache.camel.Route;
+import org.apache.camel.component.file.remote.SftpConsumer;
+import org.apache.camel.component.quartz.QuartzEndpoint;
+import org.apache.camel.pollconsumer.quartz.QuartzScheduledPollConsumerScheduler;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.quartz.*;
+import org.qubership.integration.platform.engine.camel.metadata.Metadata;
+import org.qubership.integration.platform.engine.camel.metadata.MetadataService;
+import org.qubership.integration.platform.engine.testutils.DisplayNameUtils;
+
+import java.lang.reflect.Field;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameUtils.ReplaceCamelCase.class)
+class QuartzSchedulerServiceTest {
+
+    @Mock
+    Scheduler scheduler;
+    @Mock
+    MetadataService metadataService;
+
+    private QuartzSchedulerService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new QuartzSchedulerService(scheduler, metadataService);
+    }
+
+    @Test
+    void shouldDeleteJobsWhenRemoveSchedulerJobsAndListNotEmpty() throws Exception {
+        List<JobKey> jobs = List.of(JobKey.jobKey("j1", "g1"));
+        when(scheduler.deleteJobs(jobs)).thenReturn(true);
+
+        service.removeSchedulerJobs(jobs);
+
+        verify(scheduler).deleteJobs(jobs);
+    }
+
+    @Test
+    void shouldNotDeleteJobsWhenRemoveSchedulerJobsAndListEmpty() {
+        service.removeSchedulerJobs(List.of());
+
+        verifyNoInteractions(scheduler);
+    }
+
+    @Test
+    void shouldSwallowExceptionWhenRemoveSchedulerJobsThrows() throws Exception {
+        List<JobKey> jobs = List.of(JobKey.jobKey("j1", "g1"));
+        when(scheduler.deleteJobs(jobs)).thenThrow(new SchedulerException("boom"));
+
+        assertDoesNotThrow(() -> service.removeSchedulerJobs(jobs));
+
+        verify(scheduler).deleteJobs(jobs);
+    }
+
+    @Test
+    void shouldReturnSchedulerJobsFromContextForMatchingDeployment() throws Exception {
+        CamelContext context = mock(CamelContext.class);
+
+        Route quartzRoute = routeWithEndpointAndConsumer(
+                "dep-1",
+                quartzEndpointWithTrigger("tr-1", "grp-1"),
+                null
+        );
+
+        JobKey sftpJobKey = JobKey.jobKey("job-2", "grp-2");
+        Route sftpRoute = routeWithEndpointAndConsumer(
+                "dep-1",
+                mock(Endpoint.class),
+                sftpConsumerWithQuartzSchedulerJob(sftpJobKey)
+        );
+
+        Route otherDeploymentRoute = routeWithDeploymentIdOnly("dep-2");
+
+        when(context.getRoutes()).thenReturn(List.of(quartzRoute, sftpRoute, otherDeploymentRoute));
+
+        List<JobKey> result = service.getSchedulerJobsFromContext(context, "dep-1");
+
+        assertEquals(Set.of(
+                JobKey.jobKey("tr-1", "grp-1"),
+                sftpJobKey
+        ), Set.copyOf(result));
+    }
+
+    @Test
+    void shouldRemoveSchedulerJobsFromContextByDelegatingToDeleteJobs() throws Exception {
+        CamelContext context = mock(CamelContext.class);
+
+        JobKey sftpJobKey = JobKey.jobKey("job-2", "grp-2");
+        Route quartzRoute = routeWithEndpointAndConsumer(
+                "dep-1",
+                quartzEndpointWithTrigger("tr-1", "grp-1"),
+                null
+        );
+        Route sftpRoute = routeWithEndpointAndConsumer(
+                "dep-1",
+                mock(Endpoint.class),
+                sftpConsumerWithQuartzSchedulerJob(sftpJobKey)
+        );
+
+        when(context.getRoutes()).thenReturn(List.of(quartzRoute, sftpRoute));
+        when(scheduler.deleteJobs(anyList())).thenReturn(true);
+
+        service.removeSchedulerJobsFromContext(context, "dep-1");
+
+        @SuppressWarnings({"rawtypes", "unchecked"})
+        ArgumentCaptor<List<JobKey>> captor = (ArgumentCaptor) ArgumentCaptor.forClass(List.class);
+        verify(scheduler).deleteJobs(captor.capture());
+
+        List<JobKey> jobs = captor.getValue();
+        assertEquals(Set.of(JobKey.jobKey("tr-1", "grp-1"), sftpJobKey), Set.copyOf(jobs));
+    }
+
+    @Test
+    void shouldCommitScheduledJobsByDelegatingToQuartzScheduler() throws Exception {
+        JobDetail job1 = job("job-1", "grp-1");
+        Trigger trigger1 = mock(Trigger.class);
+        JobDetail job2 = job("job-2", "grp-2");
+        Trigger trigger2 = mock(Trigger.class);
+
+        service.getSchedulerProxy().scheduleJob(job1, trigger1);
+        service.getSchedulerProxy().scheduleJob(job2, trigger2);
+
+        service.commitScheduledJobs();
+
+        @SuppressWarnings({"rawtypes", "unchecked"})
+        ArgumentCaptor<Set> triggersCaptor = (ArgumentCaptor) ArgumentCaptor.forClass(Set.class);
+        ArgumentCaptor<JobDetail> jobCaptor = ArgumentCaptor.forClass(JobDetail.class);
+
+        verify(scheduler, times(2)).scheduleJob(jobCaptor.capture(), triggersCaptor.capture(), eq(true));
+
+        List<JobDetail> jobs = jobCaptor.getAllValues();
+        List<Set> triggerSets = triggersCaptor.getAllValues();
+
+        assertEquals(List.of(job1, job2), jobs);
+        assertEquals(Set.of(trigger1), triggerSets.get(0));
+        assertEquals(Set.of(trigger2), triggerSets.get(1));
+
+        service.commitScheduledJobs();
+        verifyNoMoreInteractions(scheduler);
+    }
+
+    @Test
+    void shouldClearDelayedJobsWhenResetSchedulersProxyCalled() throws SchedulerException {
+        JobDetail job1 = job("job-1", "grp-1");
+        Trigger trigger1 = mock(Trigger.class);
+
+        service.getSchedulerProxy().scheduleJob(job1, trigger1);
+
+        service.resetSchedulersProxy();
+        service.commitScheduledJobs();
+
+        verifyNoInteractions(scheduler);
+    }
+
+    @Test
+    void shouldSuspendAndResumeAllSchedulers() throws Exception {
+        when(scheduler.isInStandbyMode()).thenReturn(false);
+
+        service.suspendAllSchedulers();
+        service.resumeAllSchedulers();
+
+        InOrder inOrder = inOrder(scheduler);
+        inOrder.verify(scheduler).isInStandbyMode();
+        inOrder.verify(scheduler).standby();
+        inOrder.verify(scheduler).start();
+        inOrder.verify(scheduler).resumeAll();
+    }
+
+    private Route routeWithEndpointAndConsumer(String deploymentId, Endpoint endpoint, Consumer consumer) {
+        Route route = mock(Route.class);
+        when(route.getEndpoint()).thenReturn(endpoint);
+        when(route.getConsumer()).thenReturn(consumer);
+
+        Optional<Metadata> md = metadata(deploymentId);
+        when(metadataService.getMetadata(route)).thenReturn(md);
+
+        return route;
+    }
+
+    private Route routeWithDeploymentIdOnly(String deploymentId) {
+        Route route = mock(Route.class);
+
+        Optional<Metadata> md = metadata(deploymentId);
+        when(metadataService.getMetadata(route)).thenReturn(md);
+
+        return route;
+    }
+
+    private Optional<Metadata> metadata(String deploymentId) {
+        Metadata m = mock(Metadata.class);
+        when(m.getDeploymentId()).thenReturn(deploymentId);
+        return Optional.of(m);
+    }
+
+    private QuartzEndpoint quartzEndpointWithTrigger(String triggerName, String groupName) {
+        QuartzEndpoint endpoint = mock(QuartzEndpoint.class);
+        when(endpoint.getTriggerKey()).thenReturn(TriggerKey.triggerKey(triggerName, groupName));
+        return endpoint;
+    }
+
+    private SftpConsumer sftpConsumerWithQuartzSchedulerJob(JobKey jobKey) throws Exception {
+        SftpConsumer consumer = mock(SftpConsumer.class);
+
+        QuartzScheduledPollConsumerScheduler quartzScheduler = new QuartzScheduledPollConsumerScheduler();
+        setPrivateField(quartzScheduler, "job", job(jobKey.getName(), jobKey.getGroup()));
+
+        when(consumer.getScheduler()).thenReturn(quartzScheduler);
+        return consumer;
+    }
+
+    private JobDetail job(String name, String group) {
+        return JobBuilder.newJob(DummyJob.class).withIdentity(name, group).build();
+    }
+
+    private void setPrivateField(Object target, String fieldName, Object value) throws Exception {
+        Field f = target.getClass().getDeclaredField(fieldName);
+        f.setAccessible(true);
+        f.set(target, value);
+    }
+
+    static class DummyJob implements Job {
+        @Override
+        public void execute(JobExecutionContext context) {
+        }
+    }
+}

--- a/src/test/java/org/qubership/integration/platform/engine/service/ServiceVariableUtilsTest.java
+++ b/src/test/java/org/qubership/integration/platform/engine/service/ServiceVariableUtilsTest.java
@@ -1,0 +1,101 @@
+package org.qubership.integration.platform.engine.service;
+
+import org.apache.camel.Exchange;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.qubership.integration.platform.engine.testutils.DisplayNameUtils;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(DisplayNameUtils.ReplaceCamelCase.class)
+class ServiceVariableUtilsTest {
+
+    @Mock
+    Exchange exchange;
+
+    private ServiceVariableUtils utils;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        utils = newUtilsWithServiceVariableNames(List.of("svcA", "svcB"));
+    }
+
+    @Test
+    void shouldRemoveServiceVariablesFromExchangePropertiesWhenGetCustomProperties() {
+        Map<String, Object> props = new HashMap<>();
+        props.put("svcA", 1);
+        props.put("svcB", 2);
+        props.put("custom1", "x");
+        props.put("custom2", 123);
+
+        when(exchange.getProperties()).thenReturn(props);
+
+        Map<String, Object> result = utils.getCustomProperties(exchange);
+
+        assertEquals(Map.of("custom1", "x", "custom2", 123), result);
+    }
+
+    @Test
+    void shouldNotMutateOriginalExchangePropertiesWhenGetCustomProperties() {
+        Map<String, Object> props = new HashMap<>();
+        props.put("svcA", 1);
+        props.put("custom", "x");
+
+        when(exchange.getProperties()).thenReturn(props);
+
+        Map<String, Object> result = utils.getCustomProperties(exchange);
+
+        assertNotSame(props, result);
+        assertEquals(2, props.size());
+        assertTrue(props.containsKey("svcA"));
+        assertTrue(props.containsKey("custom"));
+        assertEquals(Map.of("custom", "x"), result);
+    }
+
+    @Test
+    void shouldReturnAllPropertiesWhenNoServiceVariablesPresent() {
+        Map<String, Object> props = new HashMap<>();
+        props.put("custom1", "x");
+        props.put("custom2", 123);
+
+        when(exchange.getProperties()).thenReturn(props);
+
+        Map<String, Object> result = utils.getCustomProperties(exchange);
+
+        assertEquals(props, result);
+    }
+
+    @Test
+    void shouldHandleEmptyPropertiesWhenGetCustomProperties() {
+        when(exchange.getProperties()).thenReturn(new HashMap<>());
+
+        Map<String, Object> result = utils.getCustomProperties(exchange);
+
+        assertTrue(result.isEmpty());
+    }
+
+    private ServiceVariableUtils newUtilsWithServiceVariableNames(List<String> names) throws Exception {
+        Constructor<ServiceVariableUtils> ctor = ServiceVariableUtils.class.getDeclaredConstructor();
+        ctor.setAccessible(true);
+        ServiceVariableUtils instance = ctor.newInstance();
+
+        Field field = ServiceVariableUtils.class.getDeclaredField("serviceVariablesName");
+        field.setAccessible(true);
+        field.set(instance, new ArrayList<>(names));
+
+        return instance;
+    }
+}

--- a/src/test/java/org/qubership/integration/platform/engine/testutils/MockExchanges.java
+++ b/src/test/java/org/qubership/integration/platform/engine/testutils/MockExchanges.java
@@ -21,6 +21,8 @@ import org.apache.camel.Exchange;
 import org.apache.camel.ExchangePropertyKey;
 import org.apache.camel.Message;
 import org.apache.camel.TypeConverter;
+import org.apache.camel.impl.DefaultCamelContext;
+import org.apache.camel.support.DefaultExchange;
 
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -29,19 +31,18 @@ import java.util.concurrent.atomic.AtomicReference;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
-
 public final class MockExchanges {
 
     private MockExchanges() {
     }
 
     public static Exchange basic() {
-        Exchange ex = mock(Exchange.class);
+        Exchange ex = mock(Exchange.class, withSettings().lenient());
 
-        ConcurrentMap<Object, Object> props = new ConcurrentHashMap<>();
+        ConcurrentMap<String, Object> props = new ConcurrentHashMap<>();
         AtomicReference<Throwable> exceptionRef = new AtomicReference<>();
 
-        doAnswer(inv -> {
+        lenient().doAnswer(inv -> {
             String key = inv.getArgument(0);
             Object val = inv.getArgument(1);
             if (val == null) {
@@ -52,7 +53,7 @@ public final class MockExchanges {
             return null;
         }).when(ex).setProperty(anyString(), any());
 
-        doAnswer(inv -> {
+        lenient().doAnswer(inv -> {
             ExchangePropertyKey key = inv.getArgument(0);
             Object val = inv.getArgument(1);
             String k = key.getName();
@@ -64,16 +65,18 @@ public final class MockExchanges {
             return null;
         }).when(ex).setProperty(any(ExchangePropertyKey.class), any());
 
-        when(ex.getProperty(anyString())).thenAnswer(inv -> props.get(inv.getArgument(0)));
+        lenient().when(ex.getProperties()).thenReturn(props);
 
-        when(ex.getProperty(anyString(), any(Class.class))).thenAnswer(inv -> {
+        lenient().when(ex.getProperty(anyString())).thenAnswer(inv -> props.get(inv.getArgument(0)));
+
+        lenient().when(ex.getProperty(anyString(), any(Class.class))).thenAnswer(inv -> {
             String key = inv.getArgument(0);
             Class<?> type = inv.getArgument(1);
             Object val = props.get(key);
             return val == null ? null : type.cast(val);
         });
 
-        when(ex.getProperty(anyString(), any(), any(Class.class))).thenAnswer(inv -> {
+        lenient().when(ex.getProperty(anyString(), any(), any(Class.class))).thenAnswer(inv -> {
             String key = inv.getArgument(0);
             Object def = inv.getArgument(1);
             Class<?> type = inv.getArgument(2);
@@ -81,14 +84,14 @@ public final class MockExchanges {
             return val == null ? def : type.cast(val);
         });
 
-        when(ex.getProperty(any(ExchangePropertyKey.class), any(Class.class))).thenAnswer(inv -> {
+        lenient().when(ex.getProperty(any(ExchangePropertyKey.class), any(Class.class))).thenAnswer(inv -> {
             ExchangePropertyKey key = inv.getArgument(0);
             Class<?> type = inv.getArgument(1);
             Object val = props.get(key.getName());
             return val == null ? null : type.cast(val);
         });
 
-        when(ex.getProperty(any(ExchangePropertyKey.class), any(), any(Class.class))).thenAnswer(inv -> {
+        lenient().when(ex.getProperty(any(ExchangePropertyKey.class), any(), any(Class.class))).thenAnswer(inv -> {
             ExchangePropertyKey key = inv.getArgument(0);
             Object def = inv.getArgument(1);
             Class<?> type = inv.getArgument(2);
@@ -96,32 +99,43 @@ public final class MockExchanges {
             return val == null ? def : type.cast(val);
         });
 
-        doAnswer(inv -> {
+        lenient().doAnswer(inv -> {
             exceptionRef.set(inv.getArgument(0));
             return null;
-        })
-                .when(ex).setException(any());
-        when(ex.getException()).thenAnswer(inv -> exceptionRef.get());
+        }).when(ex).setException(any());
+
+        lenient().when(ex.getException()).thenAnswer(inv -> exceptionRef.get());
 
         return ex;
     }
 
     public static Exchange withMessage() {
         Exchange ex = basic();
-        Message msg = mock(Message.class);
-        when(ex.getMessage()).thenReturn(msg);
-        when(ex.getIn()).thenReturn(msg);
-        when(msg.getExchange()).thenReturn(ex);
+        Message msg = mock(Message.class, withSettings().lenient());
+        lenient().when(ex.getMessage()).thenReturn(msg);
+        lenient().when(ex.getIn()).thenReturn(msg);
+        lenient().when(msg.getExchange()).thenReturn(ex);
         return ex;
     }
 
     public static Exchange withMessageAndConverter() {
         Exchange ex = withMessage();
-        CamelContext ctx = mock(CamelContext.class);
-        TypeConverter tc = mock(TypeConverter.class);
-        when(ex.getContext()).thenReturn(ctx);
-        when(ctx.getTypeConverter()).thenReturn(tc);
+        CamelContext ctx = mock(CamelContext.class, withSettings().lenient());
+        TypeConverter tc = mock(TypeConverter.class, withSettings().lenient());
+        lenient().when(ex.getContext()).thenReturn(ctx);
+        lenient().when(ctx.getTypeConverter()).thenReturn(tc);
         return ex;
+    }
+
+    public static Exchange withDefaultCamelContext() {
+        Exchange ex = basic();
+        CamelContext ctx = new DefaultCamelContext();
+        lenient().when(ex.getContext()).thenReturn(ctx);
+        return ex;
+    }
+
+    public static Exchange defaultExchange() {
+        return new DefaultExchange(new DefaultCamelContext());
     }
 
     public static TypeConverter getTypeConverter(Exchange ex) {


### PR DESCRIPTION
Tests for following services/camel custom components/utils
- ChainBlockingProducer
- ChainComponent
- ChainConsumer
- ChainEndpoint
- ChainProcessor
- ChainProducer
- GraphqlCustomComponent
- GraphqlCustomEndpoint
- GraphqlCustomProducer
- MetadataService
- QuartzSchedulerService
- SchedulerProxy
- ServiceVariableUtils

Also extend exchange mock class